### PR TITLE
Enable models for i18n

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -24,6 +24,8 @@ from standards.models import Standard, GradeBand, Category, Framework
 from documentation.models import Map
 import lessons.models
 
+from i18n.models import InternationalizablePage
+
 logger = logging.getLogger(__name__)
 
 """
@@ -32,7 +34,7 @@ Curriculum
 """
 
 
-class Curriculum(Page, RichText, CloneableMixin):
+class Curriculum(InternationalizablePage, RichText, CloneableMixin):
     CURRENT = 0
     NEXT = 1
     PAST = 2
@@ -232,7 +234,7 @@ Curricular Unit
 """
 
 
-class Unit(Page, RichText, CloneableMixin):
+class Unit(InternationalizablePage, RichText, CloneableMixin):
     curriculum = models.ForeignKey(Curriculum, blank=True, null=True)
     ancestor = models.ForeignKey('self', blank=True, null=True, on_delete=models.SET_NULL)
     disable_numbering = models.BooleanField(default=False, help_text="Override to disable unit numbering")

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -286,6 +286,7 @@ INSTALLED_APPS = (
     "reversion_compare",
     "django_slack",
     # Custom apps for Code.org curriculum
+    "i18n",
     "standards",
     "lessons",
     "curricula",

--- a/i18n/management/commands/gather_i18n_strings.py
+++ b/i18n/management/commands/gather_i18n_strings.py
@@ -7,7 +7,7 @@ import os
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        staticfiles = os.path.join(os.path.dirname(__file__), '../../static')
+        staticfiles = os.path.join(os.path.dirname(__file__), '../../static/source')
         os.makedirs(staticfiles)
 
         for model in django.apps.apps.get_models():

--- a/i18n/models.py
+++ b/i18n/models.py
@@ -11,7 +11,9 @@ class InternationalizablePage(Page):
         for obj in cls.objects.all():
             strings[obj.slug] = {}
             for field in cls.internationalizable_fields():
-                strings[obj.slug][field] = getattr(obj, field)
+                string = getattr(obj, field)
+                if string:
+                    strings[obj.slug][field] = getattr(obj, field)
         return strings
 
     @classmethod

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -24,6 +24,7 @@ from documentation.models import Block
 from django_slack import slack_message
 
 from curriculumBuilder import settings
+from i18n.models import InternationalizablePage
 
 from django_cloneable import CloneableMixin
 
@@ -210,7 +211,7 @@ Complete Lesson Page
 """
 
 
-class Lesson(Page, RichText, CloneableMixin):
+class Lesson(InternationalizablePage, RichText, CloneableMixin):
     overview = RichTextField('Lesson Overview')
     short_title = models.CharField('Short Title (optional)', help_text='Used where space is at a premium',
                                    max_length=64, blank=True, null=True)
@@ -243,6 +244,10 @@ class Lesson(Page, RichText, CloneableMixin):
 
     class Meta:
         ordering = ["number"]
+
+    @classmethod
+    def internationalizable_fields(cls):
+        return super(Lesson, cls).internationalizable_fields() + ['overview', 'short_title', 'cs_content', 'prep']
 
     def __unicode__(self):
         return self.title


### PR DESCRIPTION
Using the new i18n module, flag some models to be internationalized so we can start syncing their strings up to crowdin.

Depends on https://github.com/mrjoshida/curriculumbuilder/pull/4