### PR TITLE
Enable crowdin-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ docker-compose\.dev\.yml
 *.sql
 
 heroku\.env
+
+crowdin_credentials.yml

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,46 @@
+#
+# Your crowdin's credentials
+#
+"project_identifier" : "curriculumbuilder"
+"base_path" : "./i18n/static"
+
+# API Credentials must be loaded from a separate identity file. See
+# https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
+"api_key" : ""
+
+#
+# Choose file structure in crowdin
+# e.g. true or false
+#
+"preserve_hierarchy": false
+
+#
+# Files configuration
+#
+files: [
+ {
+  #
+  # Source files filter
+  # e.g. "/resources/en/*.json"
+  #
+  "source" : "source/*.json",
+
+  #
+  # where translations live
+  # e.g. "/resources/%two_letters_code%/%original_file_name%"
+  #
+  "translation" : "%locale%/%original_file_name%",
+
+  #
+  # File type
+  # e.g. "json"
+  #
+  "type" : "json",
+
+  #
+  # The parameter "update_option" is optional. If it is not set, translations for changed strings will be lost. Useful for typo fixes and minor changes in source strings.
+  # e.g. "update_as_unapproved" or "update_without_changes"
+  #
+  "update_option" : "update_without_changes",
+ }
+]


### PR DESCRIPTION
Add a crowdin CLI config file and support for a gitignored crowdin credentials file.

This will enable us to upload strings to be translated to the new crowdin project here https://crowdin.com/project/curriculumbuilder