### PR TITLE
render translated content

### DIFF
--- a/i18n/models.py
+++ b/i18n/models.py
@@ -7,14 +7,24 @@ import time
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import models
+from django.utils import translation
 
 from mezzanine.pages.models import Page
 
 
-class Internationalizable:
+class Internationalizable(models.Model):
 
     class Meta:
         abstract = True
+
+    @classmethod
+    def from_db(cls, *args):
+        instance = super(Internationalizable, cls).from_db(*args)
+        lang = translation.get_language()
+        if lang and lang != settings.LANGUAGE_CODE:
+            instance.translate_to(lang)
+        return instance
 
     @classmethod
     def internationalizable_fields(cls):
@@ -103,7 +113,7 @@ class Internationalizable:
             # exists but has not yet been translated
             return ""
 
-class InternationalizablePage(Internationalizable, Page):
+class InternationalizablePage(Page, Internationalizable):
 
     class Meta:
         abstract = True

--- a/i18n/models.py
+++ b/i18n/models.py
@@ -4,6 +4,8 @@ import sys
 import time
 
 from mezzanine.pages.models import Page
+import json
+import os
 
 class Internationalizable:
 
@@ -77,3 +79,22 @@ class InternationalizablePage(Internationalizable, Page):
     @classmethod
     def internationalizable_fields(cls):
         return ['title', 'description']
+
+    def translate_to(self, lang):
+        for field in self.__class__.internationalizable_fields():
+            translated = self.get_translated_field(field, lang)
+            if translated:
+                print(translated)
+            else:
+                print("nope")
+            if translated:
+                setattr(self, field, translated)
+
+    def get_translated_field(self, field, lang):
+        translation_file = os.path.join(os.path.dirname(__file__), 'static', lang, self.__class__.__name__ + '.json')
+        translations = json.load(open(translation_file))
+        print(self.slug)
+        try:
+            return translations[self.slug][field]
+        except KeyError:
+            return ""

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -523,7 +523,7 @@ Activities that compose a lesson
 """
 
 
-class Activity(Internationalizable, Orderable, CloneableMixin):
+class Activity(Orderable, CloneableMixin, Internationalizable):
     name = models.CharField(max_length=255)
     content = RichTextField('Activity Content')
     keywords = KeywordsField()


### PR DESCRIPTION
Depends on https://github.com/mrjoshida/curriculumbuilder/pull/20

Enabling the i18n routes enables the current locale to be set and read from `django.utils.translation`; this PR updates the Internationalizable abstract model to cause all instances of the class to translate themselves based on the current locale as they come out of the database.

Specifically, they do this by grabbing the appropriate i18n file, parsing it as JSON (and caching that result so this process isn't _horribly_ expensive, just somewhat so), and using `setattr` to replace the appropriate field value with the translated result. This is more than a bit clumsy, but it means we get i18n for free without needing to update templates to use internationalizable versions of the fields or perform a migration to replace the existing fields with new dynamic properties.

We might want to take on one of those solutions at some point in the future, but for now this gets us where we need to be.

The end result of all of this is that if we have an i18n file that looks like:

```json
{
    "test-unit/advanced-test-lesson": {
      "title": "Lección de prueba avanzada",
      "overview": "Esta es la larga *descripción*",
      "description": "Esta es la larga *descripción*"
    }
}
```

Then we can do this (note the urls):

_ | English | Spanish
--- | --- | ---
Lesson view | ![image](https://user-images.githubusercontent.com/244100/40089219-7140fa66-585f-11e8-943a-e44cd9a2fd46.png) | ![image](https://user-images.githubusercontent.com/244100/40089238-868dd06a-585f-11e8-8863-22d3875afd8b.png)
Unit view | ![image](https://user-images.githubusercontent.com/244100/40089272-ba3f627a-585f-11e8-89cd-8458d881c613.png) | ![image](https://user-images.githubusercontent.com/244100/40089266-b02b7738-585f-11e8-9d42-af6dc3c65dff.png)
