### PR TITLE
Fix unit renumbering to fix cloning

### DIFF
--- a/curriculumBuilder/numbering_patch.py
+++ b/curriculumBuilder/numbering_patch.py
@@ -70,6 +70,7 @@ def update_numbering(page):
         unit = page.chapter.unit
     elif page.content_model == 'unit':
         unit = page.unit
+        unit.curriculum.renumber_units()
 
     unit.renumber_lessons()
 


### PR DESCRIPTION
Cloning (and move operations) were attempting to call lesson renumbering before the unit had been fully saved, and in cases where renumbering was unnecessary. This pulls that behavior, and instead renumbers units when units are cloned (this assumes that lesson numbers shouldn't change when a unit is cloned).