### PR TITLE
Change course overview page

### DIFF
--- a/curricula/templates/curricula/curriculum.html
+++ b/curricula/templates/curricula/curriculum.html
@@ -23,7 +23,6 @@
 {% endblock %}
 
 {% block extra_css %}
-    <link rel="stylesheet" href="{% static "css/lesson.css" %}">
     <link rel="stylesheet" href="{% static "css/bootstrap-drawer.min.css" %}">
 {% endblock %}
 {% block extra_js %}
@@ -66,9 +65,34 @@
 {% endblock %}
 
 {% block main %}
-    {% editable curriculum.content %}
-    {{ curriculum.content|richtext_filters|safe }}
-    {% endeditable %}
+
+    <div class="together overview-page row">
+
+        <div class="col-sm-7 left-col">
+
+            {% editable curriculum.content %}
+            {{ curriculum.content|richtext_filters|safe }}
+            {% endeditable %}
+
+        </div>
+
+    <div class="col-sm-5 right-col">
+
+<!-- Sidebar -->
+
+        <h2>Units</h2>
+        {% for unit in units %}
+            <h3>{{ unit.long_name }}</h3>
+            <p>
+            {{ unit.description|truncatechars:160 }}
+            <a href="{% url 'curriculum:unit_view' curriculum.slug unit.slug %}" data-pdf-link="#unit{{ unit.number }}"> more</a>
+            </p>
+        {% endfor %}
+
+    </div>
+
+</div>
+
     <div class="topics">
         {% if curriculum.topics.count > 0 %}
             {% for topic in curriculum.topics.all %}
@@ -81,14 +105,6 @@
             {% endfor %}
         {% endif %}
     </div>
-    {% for unit in units %}
-    <div class="together">
-        <h2><a href="{% url 'curriculum:unit_view' curriculum.slug unit.slug %}" data-pdf-link="#unit{{ unit.number }}">{{ unit.title }}</a></h2>
-        {% editable unit.description %}
-        {{ unit.description|richtext_filters|safe }}
-        {% endeditable %}
-    </div>
-    {% endfor %}
 
 {% endblock %}
 

--- a/curriculumBuilder/numbering_patch.py
+++ b/curriculumBuilder/numbering_patch.py
@@ -26,7 +26,6 @@ def custom_admin_page_ordering(request):
 
     page = get_object_or_404(Page, id=get_id(request.POST['id']))
     old_parent_id = page.parent_id
-    old_parent = Page.objects.get(id=old_parent_id)
     new_parent_id = get_id(request.POST['parent_id'])
     new_parent = Page.objects.get(id=new_parent_id) if new_parent_id else None
 
@@ -57,13 +56,14 @@ def custom_admin_page_ordering(request):
 
     update_numbering(page)
     if new_parent_id != old_parent_id:
-        update_numbering(old_parent)
+        update_numbering(Page.objects.get(id=old_parent_id))
 
     return HttpResponse("ok")
 
 
 def update_numbering(page):
 
+    unit = None
     if page.content_model == 'lesson':
         unit = page.lesson.unit
     elif page.content_model == 'chapter':
@@ -72,7 +72,8 @@ def update_numbering(page):
         unit = page.unit
         unit.curriculum.renumber_units()
 
-    unit.renumber_lessons()
+    if unit:
+        unit.renumber_lessons()
 
 
 views.admin_page_ordering = custom_admin_page_ordering

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -91,6 +91,7 @@ summary {
 .headercontent h1 {
     font-size: 50px;
     line-height: 1em;
+    margin: auto 20px;
 }
 
 .headercontent h1, .headercontent h2, .headercontent h3 {
@@ -132,10 +133,6 @@ summary {
     width: 1.5em;
     text-align: center;
     display: inline-block;
-}
-
-div.content {
-    padding-left: 40px;
 }
 
 .together {


### PR DESCRIPTION
Adding a two column layout to the course overview page so that the embedded curriculum guide can be shown next to a list of units