### PR TITLE
Add I18n whitelist logic

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -201,6 +201,10 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin):
     def units(self):
         return Unit.objects.filter(parent=self, login_required=False)
 
+    @property
+    def should_be_translated(self):
+        return self.slug == "csf-1718"
+
     # Hijacking the Mezzanine top menu to control which curricula show on the home page
     @property
     def in_main_menu(self):

--- a/i18n/models.py
+++ b/i18n/models.py
@@ -6,6 +6,10 @@ class Internationalizable:
         abstract = True
 
     @classmethod
+    def internationalizable_fields(cls):
+        return []
+
+    @classmethod
     def gather_strings(cls):
         strings = {}
         for obj in cls.objects.select_related().all():
@@ -20,10 +24,6 @@ class Internationalizable:
     @property
     def i18n_key(self):
         return self.pk
-
-    @classmethod
-    def internationalizable_fields(cls):
-        return []
 
 class InternationalizablePage(Internationalizable, Page):
 

--- a/i18n/models.py
+++ b/i18n/models.py
@@ -17,13 +17,18 @@ class Internationalizable:
     def gather_strings(cls):
         strings = {}
         for obj in cls.get_i18n_objects().all():
-            key = obj.i18n_key
-            strings[key] = {}
-            for field in cls.internationalizable_fields():
-                string = getattr(obj, field)
-                if string:
-                    strings[key][field] = getattr(obj, field)
+            if obj.should_be_translated:
+                key = obj.i18n_key
+                strings[key] = {}
+                for field in cls.internationalizable_fields():
+                    string = getattr(obj, field)
+                    if string:
+                        strings[key][field] = getattr(obj, field)
         return strings
+
+    @property
+    def should_be_translated(self):
+        return True
 
     @property
     def i18n_key(self):
@@ -37,6 +42,15 @@ class InternationalizablePage(Internationalizable, Page):
     @classmethod
     def get_i18n_objects(cls):
         return super(InternationalizablePage, cls).get_i18n_objects().select_related('parent')
+
+    @property
+    def should_be_translated(self):
+        if self.parent and isinstance(self.parent, Page):
+            real_parent = self.parent.get_content_model()
+            if isinstance(real_parent, Internationalizable):
+                return real_parent.should_be_translated
+
+        return True;
 
     @property
     def i18n_key(self):

--- a/i18n/models.py
+++ b/i18n/models.py
@@ -10,9 +10,13 @@ class Internationalizable:
         return []
 
     @classmethod
+    def get_i18n_objects(cls):
+        return cls.objects
+
+    @classmethod
     def gather_strings(cls):
         strings = {}
-        for obj in cls.objects.select_related().all():
+        for obj in cls.get_i18n_objects().all():
             key = obj.i18n_key
             strings[key] = {}
             for field in cls.internationalizable_fields():
@@ -29,6 +33,10 @@ class InternationalizablePage(Internationalizable, Page):
 
     class Meta:
         abstract = True
+
+    @classmethod
+    def get_i18n_objects(cls):
+        return super(InternationalizablePage, cls).get_i18n_objects().select_related('parent')
 
     @property
     def i18n_key(self):

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -246,6 +246,14 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
         ordering = ["number"]
 
     @classmethod
+    def get_i18n_objects(cls):
+        return super(Lesson, cls).get_i18n_objects().select_related('curriculum')
+
+    @property
+    def should_be_translated(self):
+        return self.curriculum.should_be_translated
+
+    @classmethod
     def internationalizable_fields(cls):
         return super(Lesson, cls).internationalizable_fields() + ['overview', 'short_title', 'cs_content', 'prep']
 
@@ -531,6 +539,14 @@ class Activity(Internationalizable, Orderable, CloneableMixin):
     @classmethod
     def internationalizable_fields(cls):
         return ['name', 'content']
+
+    @classmethod
+    def get_i18n_objects(cls):
+        return super(Activity, cls).get_i18n_objects().select_related('lesson', 'lesson__curriculum')
+
+    @property
+    def should_be_translated(self):
+        return self.lesson.should_be_translated
 
     @property
     def i18n_key(self):


### PR DESCRIPTION
Specifically, add two things: the ability for Internationalizable models to have some degree of control over the query used to gather their i18n strings, and the ability for them to declare custom logic to determine whether or not any instance should be translated. (the first thing being used to improve the performance of the second thing)

Internationalizable Pages have some default logic by which they recursively walk through their Page-provided `parent` tree, and only consider themselves to be translatable if all of their parents are.

Curriculum elements, being the root thing we want to actually make i18n decisions based on, define their own logic to only whitelist the `csf-1718` curriculum. This method can easily be overwritten in the future as our requirements change.

Finally, Lessons and Activities also provide their own `should_be_translated` logic. The the former because the default Page implementation is pretty inefficient and Lessons already do their own work to cache the Curriculum relationship, so we might as well use it. The latter because Activities are not Pages and so do not have any default logic.