### PR TITLE
Remove batch lessons

### DIFF
--- a/curricula/admin.py
+++ b/curricula/admin.py
@@ -57,7 +57,7 @@ class CurriculumAdmin(PageAdmin, VersionAdmin):
 
 class UnitAdmin(PageAdmin, VersionAdmin):
     model = Unit
-    inlines = (LessonInline, TopicInline)
+    inlines = (TopicInline, )
 
 
 class ChapterAdmin(PageAdmin):

--- a/curricula/templates/curricula/partials/lesson_front.html
+++ b/curricula/templates/curricula/partials/lesson_front.html
@@ -4,7 +4,7 @@
 <!-- One Pager -->
 
 <div class="together" id="unit{{ unit.number }}lesson{{ lesson.number }}">
-    {% editable lesson.title %}
+    {% editable lesson.title lesson.pacing_weight %}
         {% if optional %}
             <h1>Optional Lesson: {{ lesson.title }}</h1>
         {% else %}

--- a/curricula/templates/curricula/partials/pl_lesson_front.html
+++ b/curricula/templates/curricula/partials/pl_lesson_front.html
@@ -4,7 +4,7 @@
 <!-- One Pager -->
 
 <div id="unit{{ unit.number }}lesson{{ lesson.number }}">
-    {% editable lesson.title lesson.short_title lesson.duration %}
+    {% editable lesson.title lesson.short_title lesson.duration lesson.pacing_weight %}
         {% if optional %}
             <h1>Optional Lesson: {{ lesson.title }}</h1>
         {% else %}

--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -319,6 +319,7 @@ class MultiLessonAdmin(ImportExportModelAdmin):
     list_display = ('curriculum', 'unit', 'number', 'title', 'week', 'pacing_weight', 'unplugged')
     list_editable = ('title', 'week', 'pacing_weight', 'unplugged')
     list_filter = ('curriculum', 'unit', 'keywords__keyword', 'curriculum__version')
+    ordering = ('curriculum', 'unit__number', 'number')
     actions = [publish]
     form = MultiLessonForm
 


### PR DESCRIPTION
Working through some timeout issues with Dani, it looks like the embedded lessons in the unit edit form were causing issues for units with a lot of lessons (which is the case for most professional learning courses). This does two things - first it drops the embedded lessons from the unit edit page, adds some default ordering to make the multi_lesson batch edit view easier to use, and adds the pacing_weight to the front-end editor for lessons. This should account for the primary use cases for editing lessons from the unit admin.