### PR TITLE
Enable i18n routes

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -116,11 +116,12 @@ USE_TZ = True
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = "en"
+LANGUAGE_CODE = "en-us"
 
 # Supported languages
 LANGUAGES = (
-    ('en', _('English')),
+    ('en-us', _('English')),
+    ('es-mx', _('Mexican Spanish')),
 )
 
 # A boolean that turns on/off debug mode. When set to ``True``, stack traces
@@ -157,7 +158,7 @@ SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
-USE_I18N = False
+USE_I18N = True
 
 AUTHENTICATION_BACKENDS = ("mezzanine.core.auth_backends.MezzanineBackend",)
 
@@ -319,6 +320,7 @@ TEMPLATES = [{u'APP_DIRS': False,
 # these middleware classes will be applied in the order given, and in the
 # response phase the middleware will be applied in reverse order.
 MIDDLEWARE_CLASSES = (
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.gzip.GZipMiddleware',
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',
     "mezzanine.core.middleware.UpdateCacheMiddleware",

--- a/curriculumBuilder/urls.py
+++ b/curriculumBuilder/urls.py
@@ -21,6 +21,8 @@ from curricula import views
 from standards.views import *
 from gong import views as gong_views
 
+from i18n.urls import i18n_patterns_no_default_language_prefix
+
 admin.autodiscover()
 
 # Add the urlpatterns for any custom Django applications here.
@@ -66,6 +68,11 @@ if "django.contrib.admin" in settings.INSTALLED_APPS:
     ]
 
 
+urlpatterns += i18n_patterns_no_default_language_prefix('',
+        url(r'^$', views.index, name='home'),
+        url(r'^', include('curricula.urls', namespace="curriculum"))
+)
+
 urlpatterns += patterns('',
     # We don't want to presume how your homepage works, so here are a
     # few patterns you can use to set it up.
@@ -93,7 +100,6 @@ urlpatterns += patterns('',
     # should be used if you want to customize the homepage's template.
 
     # url("^$", "mezzanine.pages.views.page", {"slug": "/"}, name="home"),
-    url(r'^$', views.index, name='home'),
 
     # HOMEPAGE FOR A BLOG-ONLY SITE
     # -----------------------------
@@ -114,7 +120,6 @@ urlpatterns += patterns('',
     url("^None/$", views.index),  # Dealing with JackFrost bug
     url(r'^documentation/', include('documentation.urls', namespace="documentation")),
     url(r'^standards/', include('standards.urls', namespace="standards")),
-    url(r'^', include('curricula.urls', namespace="curriculum")),
 
     # MEZZANINE'S URLS
     # ----------------

--- a/curriculumBuilder/urls.py
+++ b/curriculumBuilder/urls.py
@@ -27,7 +27,7 @@ admin.autodiscover()
 # You can also change the ``home`` view to add your own functionality
 # to the project's homepage.
 
-urlpatterns = i18n_patterns("",
+urlpatterns = patterns("",
     # Change the admin prefix here to use an alternate URL for the
     # admin interface, which would be marginally more secure.
     (r'^admin/doc/', include('django.contrib.admindocs.urls')),

--- a/curriculumBuilder/urls.py
+++ b/curriculumBuilder/urls.py
@@ -69,8 +69,7 @@ if "django.contrib.admin" in settings.INSTALLED_APPS:
 
 
 urlpatterns += i18n_patterns_no_default_language_prefix('',
-        url(r'^$', views.index, name='home'),
-        url(r'^', include('curricula.urls', namespace="curriculum"))
+    url(r'^$', views.index, name='home'),
 )
 
 urlpatterns += patterns('',
@@ -120,6 +119,13 @@ urlpatterns += patterns('',
     url("^None/$", views.index),  # Dealing with JackFrost bug
     url(r'^documentation/', include('documentation.urls', namespace="documentation")),
     url(r'^standards/', include('standards.urls', namespace="standards")),
+)
+
+urlpatterns += i18n_patterns_no_default_language_prefix('',
+    url(r'^', include('curricula.urls', namespace="curriculum"))
+)
+
+urlpatterns += patterns('',
 
     # MEZZANINE'S URLS
     # ----------------

--- a/i18n/urls.py
+++ b/i18n/urls.py
@@ -1,0 +1,40 @@
+import re
+import warnings
+
+from django.conf import settings
+from django.conf.urls import patterns, url
+from django.core.urlresolvers import LocaleRegexURLResolver
+from django.utils import six
+from django.utils.deprecation import RemovedInDjango20Warning
+
+class LocaleRegexURLResolverNoDefaultLanguagePrefix(LocaleRegexURLResolver):
+    """
+    subclass of LocaleRegexURLResolver which overrides the regex for the default
+    language to support both prefix and non-prefix versions
+    """
+    def __init__(self, *args, **kwargs):
+        super(LocaleRegexURLResolverNoDefaultLanguagePrefix, self).__init__(*args, **kwargs)
+        self._regex_dict[settings.LANGUAGE_CODE] = re.compile('(^%s/)?' % settings.LANGUAGE_CODE, re.UNICODE)
+
+def i18n_patterns_no_default_language_prefix(prefix, *args):
+    """
+    based on django.conf.urls.i18n.i18n_patterns, but with a custom
+    LocaleRegexURLResolver specifically to avoid prefixing the default language.
+    In Django >1.10, this is provided by the prefix_default_language argument
+    (see https://docs.djangoproject.com/en/1.10/topics/i18n/translation/#django.conf.urls.i18n.i18n_patterns),
+    so if we ever upgrade to that all this can be removed
+    """
+    if isinstance(prefix, six.string_types):
+        warnings.warn(
+            "Calling i18n_patterns() with the `prefix` argument and with tuples "
+            "instead of django.conf.urls.url() instances is deprecated and "
+            "will no longer work in Django 2.0. Use a list of "
+            "django.conf.urls.url() instances instead.",
+            RemovedInDjango20Warning, stacklevel=2
+        )
+        pattern_list = patterns(prefix, *args)
+    else:
+        pattern_list = [prefix] + list(args)
+    if not settings.USE_I18N:
+        return pattern_list
+    return [LocaleRegexURLResolverNoDefaultLanguagePrefix(pattern_list)]


### PR DESCRIPTION
Enables locale-specific prefixes for homepage and all curriculum routes, to be eventually used for translated content.

After this, you will be able to access the "home page" view at any of:

- https://www.codecurricula.com/
- https://www.codecurricula.com/en-us/
- https://www.codecurricula.com/es-mx/

And similarly, all curriculum content will be accessible at (for example):

- https://www.codecurricula.com/csf-1718/coursea/1/
- https://www.codecurricula.com/en-us/csf-1718/coursea/1/
- https://www.codecurricula.com/es-mx/csf-1718/coursea/1/

 Note that this is simply enabling the routes which will eventually be used for localization. Namely, it is _not_ actually translating the content, nor is it enabling the new routes to be published out to S3. Both of those are coming in later PRs.

Open for discussion: I was thinking of including the `en-us` routes for consistency, but even after all changes are in they will still be identical to the prefix-less routes. Is it worth including them? Or would it better to just have

- https://www.codecurricula.com/
- https://www.codecurricula.com/es-mx/