### PR TITLE
Publish curriculum content in all languages

### DIFF
--- a/bin/sync-i18n.sh
+++ b/bin/sync-i18n.sh
@@ -5,4 +5,4 @@ set -e
 python manage.py gather_i18n_strings
 python manage.py i18n_sync_up
 python manage.py i18n_sync_down
-echo "i18n sync finished, content is ready to publish"
+python manage.py publish_i18n

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -16,7 +16,12 @@ class Command(BaseCommand):
             if not (is_internationalizable and is_not_proxy):
                 continue
 
-            for obj in model.objects.all():
+            name = model.__name__
+
+            if not hasattr(model, 'publish') and not hasattr(model, 'publish_pdfs'):
+                print("%s - skipping (no publish operation available)" % name)
+                continue
+
                 if not obj.should_be_translated:
                     continue
 

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -7,9 +7,11 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils import translation
 
 from i18n.models import Internationalizable
+from i18n.utils import print_clear
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
+        print("Publishing translated content")
         for model in django.apps.apps.get_models():
             is_internationalizable = issubclass(model, Internationalizable)
             is_not_proxy = not model._meta.proxy
@@ -22,6 +24,11 @@ class Command(BaseCommand):
                 print("%s - skipping (no publish operation available)" % name)
                 continue
 
+            print_clear("%s - loading" % name)
+            objects = model.get_i18n_objects()
+            total = objects.count()
+            for index, obj in enumerate(objects.all()):
+                print_clear("%s - publishing %s/%s" % (name, index, total))
                 if not obj.should_be_translated:
                     continue
 
@@ -37,3 +44,4 @@ class Command(BaseCommand):
                         list(obj.publish_pdfs())
 
                 translation.activate(original_lang)
+            print_clear("%s - finished" % name, end='\n')

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -1,0 +1,34 @@
+import json
+import os
+
+import django.apps
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import translation
+
+from i18n.models import Internationalizable
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for model in django.apps.apps.get_models():
+            is_internationalizable = issubclass(model, Internationalizable)
+            is_not_proxy = not model._meta.proxy
+            if not (is_internationalizable and is_not_proxy):
+                continue
+
+            for obj in model.objects.all():
+                if not obj.should_be_translated:
+                    continue
+
+                original_lang = translation.get_language()
+                for language_code, _ in settings.LANGUAGES:
+                    if language_code == settings.LANGUAGE_CODE:
+                        continue
+
+                    translation.activate(language_code)
+                    if hasattr(obj, 'publish'):
+                        list(obj.publish())
+                    if hasattr(obj, 'publish_pdfs'):
+                        list(obj.publish_pdfs())
+
+                translation.activate(original_lang)


### PR DESCRIPTION
Adds a new manage.py command `publish_i18n`, the companion to `gather_i18n_strings`. This command will run through all translatable content that has been marked as `should_be_translated` and initiate `publish` and `publish_pdfs` operations for that content if those are available.