### PR TITLE
Add i18n_ready field

### DIFF
--- a/curricula/migrations/0027_auto_20180522_1155.py
+++ b/curricula/migrations/0027_auto_20180522_1155.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('curricula', '0026_unitstandards'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='unit',
+            name='i18n_ready',
+            field=models.BooleanField(default=False, help_text=b'Ready for internationalization'),
+        ),
+    ]

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -204,7 +204,7 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin):
 
     @property
     def should_be_translated(self):
-        return self.slug == "csf-1718"
+        return any(unit.should_be_translated for unit in self.units)
 
     # Hijacking the Mezzanine top menu to control which curricula show on the home page
     @property
@@ -271,6 +271,10 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
 
     def __unicode__(self):
         return self.title
+
+    @property
+    def should_be_translated(self):
+        return self.i18n_ready
 
     def can_move(self, request, new_parent):
         parent_type = getattr(new_parent, 'content_model', None)

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -267,6 +267,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
     lesson_template_override = models.CharField(max_length=255, blank=True, null=True,
                                                 help_text='Override default lesson template,'
                                                           'eg curricula/pl_lesson.html')
+    i18n_ready = models.BooleanField(default=False, help_text="Ready for internationalization")
 
     def __unicode__(self):
         return self.title

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -247,11 +247,11 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
 
     @classmethod
     def get_i18n_objects(cls):
-        return super(Lesson, cls).get_i18n_objects().select_related('curriculum')
+        return super(Lesson, cls).get_i18n_objects().select_related('unit')
 
     @property
     def should_be_translated(self):
-        return self.curriculum.should_be_translated
+        return self.unit and self.unit.should_be_translated
 
     @classmethod
     def internationalizable_fields(cls):
@@ -542,7 +542,7 @@ class Activity(Internationalizable, Orderable, CloneableMixin):
 
     @classmethod
     def get_i18n_objects(cls):
-        return super(Activity, cls).get_i18n_objects().select_related('lesson', 'lesson__curriculum')
+        return super(Activity, cls).get_i18n_objects().select_related('lesson', 'lesson__unit')
 
     @property
     def should_be_translated(self):


### PR DESCRIPTION
So units can be manually flagged as ready for internationalization.

Also update the various `should_be_translated` logics to rely on the field. Specifically, curricula are now translated if any of their units have been flagged, and all entities under Unit in the hierarchy (Chapter, Lesson, Activity) are translated iff their Unit is.