### PR TITLE
Sync translations with Crowdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docker-compose\.dev\.yml
 *.sql
 
 heroku\.env
+.apt
 
 crowdin_credentials.yml
 node_modules

--- a/app.json
+++ b/app.json
@@ -12,6 +12,9 @@
     "AWS_SECRET_ACCESS_KEY": {
       "required": true
     },
+    "CROWDIN_API_KEY": {
+      "required": true
+    },
     "DJANGO_LOG_LEVEL": {
       "required": true
     },

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -42,5 +42,14 @@ files: [
   # e.g. "update_as_unapproved" or "update_without_changes"
   #
   "update_option" : "update_without_changes",
+
+  # Map crowdin's language code to Django
+  "languages_mapping": {
+    "locale": {
+      "es-MX": "es-mx",
+      "it": "it-it",
+      "th": "th-th",
+    }
+  }
  }
 ]

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -23,7 +23,7 @@ files: [
   # Source files filter
   # e.g. "/resources/en/*.json"
   #
-  "source" : "source/*.json",
+  "source" : "redacted/*.json",
 
   #
   # where translations live

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,9 +4,9 @@
 "project_identifier" : "curriculumbuilder"
 "base_path" : "./i18n/static"
 
-# API Credentials must be loaded from a separate identity file. See
-# https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
-"api_key" : ""
+# API Credentials must be provided in the CROWDIN_API_KEY environment variable
+# https://support.crowdin.com/configuration-file/#api-credentials-from-environment-variables
+"api_key_env": CROWDIN_API_KEY
 
 #
 # Choose file structure in crowdin

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -29,7 +29,7 @@ files: [
   # where translations live
   # e.g. "/resources/%two_letters_code%/%original_file_name%"
   #
-  "translation" : "%locale%/%original_file_name%",
+  "translation" : "/translations/%locale%/%original_file_name%",
 
   #
   # File type

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -122,6 +122,8 @@ LANGUAGE_CODE = "en-us"
 LANGUAGES = (
     ('en-us', _('English')),
     ('es-mx', _('Mexican Spanish')),
+    ('it-it', _('Italian')),
+    ('th-th', _('Thai')),
 )
 
 # A boolean that turns on/off debug mode. When set to ``True``, stack traces

--- a/i18n/heroku_crowdin.sh
+++ b/i18n/heroku_crowdin.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script exists solely to run heroku on crowdin. It's necessary for two
+# reasons:
+#
+# First, the heroku apt buildpack doesn't correctly add the installed crowdin
+# binary to the path (see https://github.com/heroku/heroku-buildpack-apt/pull/10)
+#
+# Second, the heroku apt buildpack also doesn't add the java executable to the
+# path. This might be because the default-jre package expects
+# update-alternatives to set up the symlinks, but the actual cause is unclear.
+#
+# Either way, this script exists solely to get around that, and if we are ever
+# able to come up with a clean way to install the crowdin-cli and its
+# dependencies on heroku this can be removed.
+
+apt_dir="${BASH_SOURCE%/*}/../.apt/"
+$apt_dir/usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_dir/usr/local/bin/crowdin-cli.jar" "$@"

--- a/i18n/models.py
+++ b/i18n/models.py
@@ -79,7 +79,7 @@ class Internationalizable(models.Model):
                 setattr(self, field, translated)
 
     def load_translations(self, lang):
-        translation_file = os.path.join(os.path.dirname(__file__), 'static', lang, self.__class__.__name__ + '.json')
+        translation_file = os.path.join(os.path.dirname(__file__), 'static', 'translations', lang, self.__class__.__name__ + '.json')
         cached = cache.get(translation_file)
         if cached is None:
             try:

--- a/i18n/sync-down.sh
+++ b/i18n/sync-down.sh
@@ -2,13 +2,14 @@
 
 shopt -s nullglob
 
-i18n_dir="${BASH_SOURCE%/*}/static"
-source_dir="$i18n_dir/source"
-locale_dir="$i18n_dir/translations"
+i18n_dir="${BASH_SOURCE%/*}"
+static_dir="$i18n_dir/static"
+source_dir="$static_dir/source"
+locale_dir="$static_dir/translations"
 
 echo "Downloading translations to $locale_dir"
 
-crowdin --config $i18n_dir/../../crowdin.yml --identity $i18n_dir/../../crowdin_credentials.yml download
+$i18n_dir/heroku_crowdin.sh --config $i18n_dir/../crowdin.yml --identity $i18n_dir/../crowdin_credentials.yml download
 
 echo "Restoring translations from $source_dir:"
 

--- a/i18n/sync-down.sh
+++ b/i18n/sync-down.sh
@@ -9,7 +9,7 @@ locale_dir="$static_dir/translations"
 
 echo "Downloading translations to $locale_dir"
 
-$i18n_dir/heroku_crowdin.sh --config $i18n_dir/../crowdin.yml --identity $i18n_dir/../crowdin_credentials.yml download
+$i18n_dir/heroku_crowdin.sh --config $i18n_dir/../crowdin.yml download
 
 echo "Restoring translations from $source_dir:"
 

--- a/i18n/sync-down.sh
+++ b/i18n/sync-down.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+shopt -s nullglob
+
+i18n_dir="${BASH_SOURCE%/*}/static"
+source_dir="$i18n_dir/source"
+locale_dir="$i18n_dir/translations"
+
+echo "Downloading translations to $locale_dir"
+
+crowdin --config $i18n_dir/../../crowdin.yml --identity $i18n_dir/../../crowdin_credentials.yml download
+
+echo "Restoring translations from $source_dir:"
+
+locales=($locale_dir/*)
+num_locales=${#locales[@]}
+for source_file in $source_dir/*; do
+  filename=${source_file#$source_dir/}
+  for index in ${!locales[@]}; do
+    locale=${locales[index]#$locale_dir/}
+    locale_file=${locales[index]}/$filename
+    echo -ne "$filename - restoring $locale_file ($((index+1))/$num_locales)\r"
+    restore -s $source_file -r $locale_file -o $locale_file
+  done
+  echo -e "\r\033[K$filename - finished"
+done

--- a/i18n/sync-up.sh
+++ b/i18n/sync-up.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+shopt -s nullglob
+
+i18n_dir="${BASH_SOURCE%/*}/static"
+source_dir="$i18n_dir/source"
+redacted_dir="$i18n_dir/redacted"
+
+mkdir -p $redacted_dir
+
+echo "Redacting sources in $source_dir to $redacted_dir"
+
+for source_file in $source_dir/*; do
+  filename=${source_file#$source_dir/}
+  redacted_file=$redacted_dir/$filename
+  redact $source_file -o $redacted_file
+  echo $filename
+done
+
+echo "Uploading redacted sources"
+
+crowdin --config $i18n_dir/../../crowdin.yml --identity $i18n_dir/../../crowdin_credentials.yml upload sources

--- a/i18n/sync-up.sh
+++ b/i18n/sync-up.sh
@@ -2,9 +2,10 @@
 
 shopt -s nullglob
 
-i18n_dir="${BASH_SOURCE%/*}/static"
-source_dir="$i18n_dir/source"
-redacted_dir="$i18n_dir/redacted"
+i18n_dir="${BASH_SOURCE%/*}"
+static_dir="$i18n_dir/static"
+source_dir="$static_dir/source"
+redacted_dir="$static_dir/redacted"
 
 mkdir -p $redacted_dir
 
@@ -19,4 +20,4 @@ done
 
 echo "Uploading redacted sources"
 
-crowdin --config $i18n_dir/../../crowdin.yml --identity $i18n_dir/../../crowdin_credentials.yml upload sources
+$i18n_dir/heroku_crowdin.sh --config $i18n_dir/../crowdin.yml --identity $i18n_dir/../crowdin_credentials.yml upload sources

--- a/i18n/sync-up.sh
+++ b/i18n/sync-up.sh
@@ -20,4 +20,4 @@ done
 
 echo "Uploading redacted sources"
 
-$i18n_dir/heroku_crowdin.sh --config $i18n_dir/../crowdin.yml --identity $i18n_dir/../crowdin_credentials.yml upload sources
+$i18n_dir/heroku_crowdin.sh --config $i18n_dir/../crowdin.yml upload sources


### PR DESCRIPTION
Depends on https://github.com/mrjoshida/curriculumbuilder/pull/25

Add two scripts:

- `sync-up` will redact all the i18n source files gathered by `manage.py gather_i18n_sources` and upload the redacted content to crowdin
- `sync-down` will download all (redacted) translations from crowdin, and restore them using the source files.

After both of these scripts have completed successfully, we will probably want to finish by invoking a locale-specific publish operation which will be constructed as a manage.py script. (coming soon in a future PR)

I figure we'll probably want to use something like https://elements.heroku.com/addons/scheduler to run these scripts once a day or so. Thoughts?