### PR TITLE
Fix activity i18n key

### DIFF
--- a/lessons/models.py
+++ b/lessons/models.py
@@ -550,7 +550,7 @@ class Activity(Orderable, CloneableMixin, Internationalizable):
 
     @property
     def i18n_key(self):
-        return "%s/%s" % (self.lesson.i18n_key, self.name)
+        return "%s/%s" % (self.lesson.i18n_key, self.get_untranslated_field('name'))
 
     def __unicode__(self):
         if self.time:


### PR DESCRIPTION
Activities were using their `name` value to build the i18n key, but that's one of the fields on name that actually gets _translated_, which was messing some things up.

To fix it, add a simple process for saving the original, untranslated values when we go through and translate a piece of content, then reference that when building the i18n key.