### PR TITLE
Add a banner to old versions of curricula that link to the latest

### DIFF
--- a/templates/basecurriculum.html
+++ b/templates/basecurriculum.html
@@ -64,6 +64,13 @@
 {% endblock %}
 
 <div class="container">
+
+{% if curriculum.version == 2 %}
+    <div class="alert alert-info alert-dismissible no_print" role="alert">
+        <strong>Heads up</strong> a newer version of this curriculum is available. Check it out <a href="/{{ curriculum.get_canonical_slug }}/" class="alert-link">here</a>.
+    </div>
+{% endif %}
+
     {% block header %}
     <div class="header printbackground">
         <div class="logo">


### PR DESCRIPTION
There are currently no routes built for the canonical_url, so I'm constructing the link manually for now with django redirects. In the future I want to build out a more robust redirection system for versions.

![image](https://user-images.githubusercontent.com/2744615/40933920-ebd18790-67e7-11e8-8e92-f36c19b394b9.png)
