### PR TITLE
Update a couple links to use get_standards_url rather than assembling it manually

### DIFF
--- a/curricula/templates/curricula/codestudiolesson.html
+++ b/curricula/templates/curricula/codestudiolesson.html
@@ -204,7 +204,7 @@
 {% if lesson.standards.count > 0 %}
 <div class="standards">
     <h2>Standards Alignment</h2>
-    <h4><a href="/{{ curriculum.slug }}/standards/">View full course alignment</a></h4>
+    <h4><a href="{{ curriculum.get_standards_url }}">View full course alignment</a></h4>
     {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
 </div>
 {% endif %}

--- a/curricula/templates/curricula/pl_lesson.html
+++ b/curricula/templates/curricula/pl_lesson.html
@@ -203,7 +203,7 @@
 
 <div class="standards">
     <h2>Standards Alignment</h2>
-    <h4><a href="/{{ curriculum.slug }}/standards/">View full course alignment</a></h4>
+    <h4><a href="{{ curriculum.get_standards_url }}">View full course alignment</a></h4>
     {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
 </div>
 {% endcomment %}


### PR DESCRIPTION
To ensure that they link to the locale-specific version of the standards when in locale mode