### PR TITLE
Use latest version of redactable-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@code-dot-org/redactable-markdown": "^0.1.2"
+    "@code-dot-org/redactable-markdown": "^0.2.0"
   }
 }


### PR DESCRIPTION
To pick up this change
https://github.com/code-dot-org/redactable-markdown/pull/36 which will
allow us to stop adding unnecessary newlines to all our translations