### PR TITLE
Standards opportunities

### DIFF
--- a/curricula/migrations/0028_auto_20180711_1235.py
+++ b/curricula/migrations/0028_auto_20180711_1235.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('curricula', '0027_auto_20180522_1155'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='unitstandards',
+            options={'ordering': ('_order',), 'verbose_name': 'Unit Standards', 'verbose_name_plural': 'Unit Standards'},
+        ),
+    ]

--- a/curricula/templates/curricula/codestudiolesson.html
+++ b/curricula/templates/curricula/codestudiolesson.html
@@ -206,6 +206,9 @@
     <h2>Standards Alignment</h2>
     <h4><a href="/{{ curriculum.slug }}/standards/">View full course alignment</a></h4>
     {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
+    <h2>Cross-curricular Opportunities</h2>
+    <h6>These standards represent potential opportunities for standards alignment in other content areas</h6>
+    {% include "standards/partials/standard_list.html" with standards=lesson.opportunity_standards.all %}
 </div>
 {% endif %}
 

--- a/curricula/templates/curricula/codestudiolesson.html
+++ b/curricula/templates/curricula/codestudiolesson.html
@@ -206,8 +206,13 @@
     <h2>Standards Alignment</h2>
     <h4><a href="/{{ curriculum.slug }}/standards/">View full course alignment</a></h4>
     {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
+</div>
+{% endif %}
+
+{% if lesson.opportunity_standards.count > 0 %}
+<div class="standards">
     <h2>Cross-curricular Opportunities</h2>
-    <h6>These standards represent potential opportunities for standards alignment in other content areas</h6>
+    <p>This list represents opportunities in this lesson to support standards in other content areas.</p>
     {% include "standards/partials/standard_list.html" with standards=lesson.opportunity_standards.all %}
 </div>
 {% endif %}

--- a/curricula/templates/curricula/lesson-overview.html
+++ b/curricula/templates/curricula/lesson-overview.html
@@ -41,7 +41,7 @@
     <ul>
         {% for block in lesson.blocks.all %}
             <li><code class="block" style="background-color: {{ block.parent_cat.color }}">
-                <a href="{{ block.get_published_url }}">{{ block.code }}</a>
+                <a href="{{ block.get_published_url }}" target="_blank">{{ block.code }}</a>
             </code></li>
         {% endfor %}
     </ul>

--- a/curriculumBuilder/resourcelinks.py
+++ b/curriculumBuilder/resourcelinks.py
@@ -29,7 +29,7 @@ class AttrTagPattern(Pattern):
     except Resource.DoesNotExist:
       print "slug not found, trying name"
       try:
-        resource = Resource.objects.get(name=el.text)
+        resource = Resource.objects.filter(name=el.text).first()
         el.set('href', resource.fallback_url())
         el.text = str(resource)
 

--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -247,8 +247,8 @@ class LessonForm(ModelForm):
         if self.fields.get('standards', False):
             self.fields['standards'].queryset = standards_queryset
 
-        if self.fields.get('anchor_standards', False):
-            self.fields['anchor_standards'].queryset = standards_queryset
+        if self.fields.get('opportunity_standards', False):
+            self.fields['opportunity_standards'].queryset = standards_queryset
 
         '''
         Optimize loading of blocks with related IDEs
@@ -264,7 +264,7 @@ class LessonAdmin(PageAdmin, AjaxSelectAdmin, CompareVersionAdmin):
 
     inlines = [ObjectiveInline, ResourceInline, ActivityInline]
 
-    filter_horizontal = ('standards', 'anchor_standards', 'vocab', 'blocks')
+    filter_horizontal = ('standards', 'opportunity_standards', 'vocab', 'blocks')
 
     fieldsets = (
         (None, {
@@ -280,7 +280,7 @@ class LessonAdmin(PageAdmin, AjaxSelectAdmin, CompareVersionAdmin):
             'classes': ['collapse-closed'],
         }),
         ('Standards', {
-            'fields': ['standards', 'anchor_standards'],
+            'fields': ['standards', 'opportunity_standards'],
             'classes': ['collapse-closed'],
         }),
     )
@@ -291,7 +291,7 @@ class LessonAdmin(PageAdmin, AjaxSelectAdmin, CompareVersionAdmin):
 
     def get_queryset(self, request):
         return super(LessonAdmin, self).get_queryset(request).select_related('parent', 'page_ptr') \
-            .prefetch_related('standards', 'anchor_standards',
+            .prefetch_related('standards', 'opportunity_standards',
                               'vocab', 'resources', 'activity_set')
 
 
@@ -325,7 +325,7 @@ class MultiLessonAdmin(ImportExportModelAdmin):
 
     inlines = [ObjectiveInline, ResourceInline, ActivityInline]
 
-    filter_horizontal = ('standards', 'anchor_standards', 'vocab', 'blocks')
+    filter_horizontal = ('standards', 'opportunity_standards', 'vocab', 'blocks')
 
     fieldsets = (
         (None, {
@@ -341,7 +341,7 @@ class MultiLessonAdmin(ImportExportModelAdmin):
             'classes': ['collapse-closed'],
         }),
         ('Standards', {
-            'fields': ['standards', 'anchor_standards'],
+            'fields': ['standards', 'opportunity_standards'],
             'classes': ['collapse-closed'],
         }),
     )

--- a/lessons/migrations/0038_lesson_opportunity_standards.py
+++ b/lessons/migrations/0038_lesson_opportunity_standards.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('standards', '0006_auto_20170929_1528'),
+        ('lessons', '0037_auto_20180426_0941'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='lesson',
+            name='opportunity_standards',
+            field=models.ManyToManyField(help_text=b'Opportunities for content standards alignment', related_name='opportunities', to='standards.Standard', blank=True),
+        ),
+    ]

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -232,6 +232,8 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
     standards = models.ManyToManyField(Standard, blank=True)
     anchor_standards = models.ManyToManyField(Standard, help_text='1 - 3 key standards this lesson focuses on',
                                               related_name="anchors", blank=True)
+    opportunity_standards = models.ManyToManyField(Standard, help_text='Opportunities for content standards alignment',
+                                                   related_name="opportunities", blank=True)
     vocab = models.ManyToManyField(Vocab, blank=True)
     blocks = models.ManyToManyField(Block, blank=True, related_name='lessons')
     comments = CommentsField()


### PR DESCRIPTION
There are some cases where we want to claim a lighter weight standards alignment, which could be better identified as "opportunities for alignment" - specifically when talking about Common Core / NGSS standars in CSF. This adds a separate field to track those standards so that we can call them out as such in lesson plans.