### PR TITLE
List related lessons on resource edit view

### DIFF
--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -213,6 +213,24 @@ class LessonInline(TabularDynamicInlineAdmin):
     keywords = KeywordsField()
 
 
+class LessonResourceInline(admin.TabularInline):
+    model = Lesson.resources.through
+    extra = 0
+    raw_id_fields = ['lesson']
+    show_change_link = True
+
+    fields = ['resource_lesson', 'lesson']
+    readonly_fields = ['resource_lesson']
+
+    def resource_lesson(self, instance):
+        return "%s %s #%d: %s" % (instance.lesson.curriculum,
+                                  instance.lesson.unit,
+                                  instance.lesson.number,
+                                  instance.lesson.title)
+
+    resource_lesson.short_description = 'Lessons'
+
+
 class LessonForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(LessonForm, self).__init__(*args, **kwargs)
@@ -372,7 +390,9 @@ class ResourceAdmin(AjaxSelectAdmin, ImportExportModelAdmin):
 
     list_display = ('name', 'type', 'student', 'gd', 'url', 'dl_url')
     list_editable = ('type', 'student', 'gd', 'url', 'dl_url')
-    list_filter = ('lesson__curriculum',)
+    list_filter = ('lessons__curriculum',)
+    inlines = [LessonResourceInline]
+    fields = ['name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug']
 
 
 class VocabAdmin(ImportExportModelAdmin):

--- a/lessons/migrations/0039_auto_20180801_1109.py
+++ b/lessons/migrations/0039_auto_20180801_1109.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sortedm2m.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lessons', '0038_lesson_opportunity_standards'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='lesson',
+            name='resources',
+            field=sortedm2m.fields.SortedManyToManyField(help_text=None, related_name='lessons', to='lessons.Resource', blank=True),
+        ),
+    ]

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -222,7 +222,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
     pacing_weight = models.DecimalField('Pacing Weight', help_text='Higher numbers take up more space pacing calendar',
                                         default=1, max_digits=4, decimal_places=1, blank=True, null=True)
     unplugged = models.BooleanField(default=False)
-    resources = SortedManyToManyField(Resource, blank=True)
+    resources = SortedManyToManyField(Resource, blank=True, related_name='lessons')
     prep = RichTextField('Preparation', help_text='ToDos for the teacher to prep this lesson', blank=True, null=True)
     questions = RichTextField('Support Details', help_text='Open questions or comments about this lesson',
                               blank=True, null=True)


### PR DESCRIPTION
Adding a list of related lessons to the resource edit view so that we can more easily track down all of the places a resource is linked to a lesson. Note that this doesn't account for cases where a writer references a resource by md tag (eg `[r resource-slug]`), only where they've properly attached the resource to the lesson.
![image](https://user-images.githubusercontent.com/2744615/43541271-d6882366-957e-11e8-8fc2-d30ff6c862a3.png)
