### PR TITLE
enable Resources for translation

### DIFF
--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -392,7 +392,7 @@ class ResourceAdmin(AjaxSelectAdmin, ImportExportModelAdmin):
     list_editable = ('type', 'student', 'gd', 'url', 'dl_url')
     list_filter = ('lessons__curriculum',)
     inlines = [LessonResourceInline]
-    fields = ['name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug']
+    fields = ['name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug', 'force_i18n']
 
 
 class VocabAdmin(ImportExportModelAdmin):

--- a/lessons/migrations/0040_resource_force_i18n.py
+++ b/lessons/migrations/0040_resource_force_i18n.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lessons', '0039_auto_20180801_1109'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resource',
+            name='force_i18n',
+            field=models.BooleanField(default=False, help_text=b'\n        By default, only Resources that have been associated with a Lesson that\n        is itself being internationalized will be internationalized. However, we\n        occasionally want to be able to include Resources inline in markdown,\n        and those Resources will not be automatically synced.\n\n        Use this flag if for that or any other reason you would like to force a\n        Resource to be synced.\n    '),
+        ),
+    ]


### PR DESCRIPTION
Specifically, sync with Crowdin those Resources that are associated with a Lesson that is also being synced, which will cover the 180 Resources that are currently explicitly associated with a CSF lesson.

Also provide an override flag so we can manually enable additional Resources. Say, for example, those Resources that are included merely as markdown links.

![image](https://user-images.githubusercontent.com/244100/43609005-a99c4290-9657-11e8-8b42-46a00b08f8dd.png)
