### PR TITLE
Restructure URLs for level embedding

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags no_autoplay level_link %}
+{% load mezzanine_tags no_autoplay level_link level_embed %}
 
 <div id="{{ unit.slug }}-stage-{{ lesson.number }}-levels" class="stage_guide_hidden">
 
@@ -69,7 +69,7 @@
                         <!-- Include contained levels for predictions -->
                         {% if level.reference  and not pdf %}
                         <div class="curriculum-reference">
-                            <iframe frameborder="0" class="map-embed" src="https://curriculum.code.org{{ level.reference }}" width="100%" height="500"></iframe>
+                            <iframe frameborder="0" class="map-embed" src="{{ level.reference|level_embed }}" width="100%" height="500"></iframe>
                         </div>
                         {% endif %}
 

--- a/curricula/templatetags/level_embed.py
+++ b/curricula/templatetags/level_embed.py
@@ -1,0 +1,20 @@
+import re
+from django import template
+
+register = template.Library()
+
+URL_RE = '^/(?P<sub>\w+)(?P<path>.+$)'
+
+@register.filter(name='level_embed')
+def level_embed(link):
+    match = re.match(URL_RE, link)
+    if match is not None:
+        try:
+            sub = match.group('sub')
+            patch = match.group('path')
+            return "https://%s.code.org%s" %(sub, patch)
+        except IndexError:
+            logger.exception('Failed to embed page' % link)
+            return link
+    else:
+        return link

--- a/curricula/templatetags/level_embed.py
+++ b/curricula/templatetags/level_embed.py
@@ -11,8 +11,8 @@ def level_embed(link):
     if match is not None:
         try:
             sub = match.group('sub')
-            patch = match.group('path')
-            return "https://%s.code.org%s" %(sub, patch)
+            path = match.group('path')
+            return "https://%s.code.org%s" %(sub, path)
         except IndexError:
             logger.exception('Failed to embed page' % link)
             return link


### PR DESCRIPTION
A while back a change was introduced to levelbuilder that restructured embedded map levels so that they could be accessed from studio.code.org instead of curriculum.code.org. This broke our ability to load those embedded levels in the code studio pullthrough because we are unable to load studio.code.org urls in an iFrame. Ideally I'd like to resolve this such that we aren't restructuring these urls on both sides, but for now this is necessary to fix the code studio pullthrough.