### PR TITLE
Remove "All Handouts PDF" link from CSF

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -280,6 +280,10 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
     def should_be_translated(self):
         return self.i18n_ready
 
+    @property
+    def has_resource_pdf(self):
+        return self.curriculum.slug not in ['csf-18', 'csf-1718']
+
     def can_move(self, request, new_parent):
         parent_type = getattr(new_parent, 'content_model', None)
         if not parent_type == 'curriculum':

--- a/curricula/templates/curricula/partials/lesson_pills.html
+++ b/curricula/templates/curricula/partials/lesson_pills.html
@@ -3,7 +3,10 @@
     <div class="btn-group btn-group-xs" role="group" aria-label="PDF Buttons">
         <a href="{{ unit.get_absolute_url }}" class="btn" role="button">Unit Overview</a>
         <a href="{{ unit.get_pdf_url }}" class="btn" role="button">All Lessons PDF</a>
+        {# Removing handouts PDF link from CSF until we can fix it #}
+        {% if unit.has_resource_pdf %}
         <a href="{{ unit.get_resources_pdf_url }}" class="btn" role="button">All Handouts PDF</a>
+        {% endif %}
         {% if changelog.count > 0 %}
 
             <div class="btn-group" role="group">

--- a/curricula/templates/curricula/partials/unit_pills.html
+++ b/curricula/templates/curricula/partials/unit_pills.html
@@ -7,7 +7,10 @@
         {% if unit.block_count > 0 %}<a href="{{ unit.get_blocks_url }}" class="btn" role="button">Code Documentation</a>{% endif %}
         <a href="{{ unit.get_resources_url }}" class="btn" role="button">Other Resources</a>
         <a href="{{ unit.get_pdf_url }}" class="btn" role="button">Lessons PDF</a>
+        {# Removing handouts PDF link from CSF until we can fix it #}
+        {% if unit.has_resource_pdf %}
         <a href="{{ unit.get_resources_pdf_url }}" class="btn" role="button">Handouts PDF</a>
+        {% endif %}
         {% if changelog.count > 0 %}
 
             <div class="btn-group" role="group">


### PR DESCRIPTION
Compiled resource PDFs have been broken in CSF for a while now and we receive consistent tickets about it. Removing the link until I have time to figure out the root cause.