### PR TITLE
Add option to exclude children when cloning.

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -234,11 +234,11 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin):
 
         if children:
             for unit in self.units.all():
-                unit.clone(attrs={'title': unit.title, 'slug': unit.slug,
-                                  'parent': duplicate.page_ptr, 'no_renumber': True})
+                unit.clone(attrs={'title': unit.title, 'slug': unit.slug,'parent': duplicate.page_ptr,
+                                  'no_renumber': True}, children=True)
 
             for map in self.maps.all():
-                map.clone(attrs={'slug': map.slug, 'title': map.title, 'parent': duplicate.page_ptr})
+                map.clone(attrs={'slug': map.slug, 'title': map.title, 'parent': duplicate.page_ptr}, children=True)
 
         # Keywords are a complex model and don't survive cloning, so we re-add here before returning the clone
         if self.keywords.count() > 0:
@@ -558,10 +558,12 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
         if children:
             if self.chapters.count() > 0:
                 for chapter in self.chapters.all():
-                    chapter.clone(attrs={'title': chapter.title, 'parent': duplicate.page_ptr, 'no_renumber': True})
+                    chapter.clone(attrs={'title': chapter.title, 'parent': duplicate.page_ptr, 'no_renumber': True},
+                                  children=True)
             else:
                 for lesson in self.lessons.all():
-                    lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr, 'no_renumber': True})
+                    lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr, 'no_renumber': True},
+                                 children=True)
 
         # Keywords are a complex model and don't survive cloning, so we re-add here before returning the clone
         if self.keywords.count() > 0:
@@ -660,7 +662,8 @@ class Chapter(InternationalizablePage, RichText, CloneableMixin):
 
         if children:
             for lesson in self.lessons.all():
-                lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr, 'no_renumber': True})
+                lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr,'no_renumber': True},
+                             children=True)
 
         if not attrs.get('no_renumber', False):
             print("renumbering lessons")

--- a/curricula/templates/curricula/curriculum.html
+++ b/curricula/templates/curricula/curriculum.html
@@ -50,6 +50,10 @@
                 {% else %}
                     <em>Can't publish, check settings in admin</em>
                 {% endif %}
+                <h2>deepSpaceCopy</h2>
+                <button class="btn btn-primary" id="clone_this" data-pk="{{ curriculum.pk }}" data-type="Curriculum">Clone</button><i id="clone_spinner"></i><br/>
+                <input type="checkbox" name="children" id="clone_children"> Clone Children</input>
+                <pre id="clone_results"></pre>
             </div>
         </div>
     </div>
@@ -216,6 +220,33 @@
                     $('#progress_spinner').removeClass('fa fa-cog fa-spin');
                 });
                 */
+            });
+            $("#clone_this").click(function () {
+                $('#clone_this').html("Cloning...").removeClass('btn-warning btn-success').addClass('btn-primary');
+                var pk = $(this).attr('data-pk');
+                var type = $(this).attr('data-type');
+                var children = $('#clone_children').prop('checked');
+                $('#clone_spinner').addClass('fa fa-cog fa-spin');
+
+                $.ajax({
+                     type: "POST",
+                     url: "/clone/",
+                     data: {pk: pk, type: type, children: children},
+                     timeout: 9999999
+                }).done(function (response) {
+                    $("#clone_this").addClass('btn-success').text("Success");
+                    $("#clone_results").text(JSON.stringify(response, undefined, 2));
+                    $('#clone_spinner').removeClass('fa fa-cog fa-spin');
+                    if (response.hasOwnProperty('redirect_url')) {
+                        setTimeout(function () {
+                            window.location.href = response.redirect_url;
+                        }, 500);
+                    }
+                }).fail(function (response) {
+                    $("#clone_this").addClass('btn-warning').text("Failed");
+                    $("#clone_results").text(JSON.stringify(response, undefined, 2));
+                    $('#clone_spinner').removeClass('fa fa-cog fa-spin');
+                });
             });
         });
     </script>

--- a/curricula/templates/curricula/unit.html
+++ b/curricula/templates/curricula/unit.html
@@ -28,6 +28,7 @@
 
 {% block admin_link %}
 {% if user.is_staff %}
+    {% comment %} ToDo: refactor admin menu out into partial {% endcomment %}
     <div id="admin_edit" class="drawer drawer-right dw-xs-9 dw-sm-5 dw-md-3 fold" aria-labelledby="admin_edit">
         <div class="drawer-controls">
             <a href="#admin_edit" data-toggle="drawer" aria-foldedopen="false" aria-controls="admin_edit" class="btn btn-default btn-md"><i class="glyphicon glyphicon-cog" aria-hidden="true"></i></a>
@@ -53,6 +54,8 @@
                 {% endif %}
                 <h2>deepSpaceCopy</h2>
                 <button class="btn btn-primary" id="clone_this" data-pk="{{ unit.pk }}" data-type="Unit">Clone</button><i id="clone_spinner"></i><br/>
+                <input type="checkbox" name="children" id="clone_children"> Clone Children</input>
+                {% comment %} ToDo: add ability to clone into a different parent {% endcomment %}
                 <pre id="clone_results"></pre>
             </div>
         </div>
@@ -306,6 +309,7 @@
 {% block footer_js %}
 
 {% if user.is_staff %}
+    {% comment %} ToDo: pull this out into a shared js file {% endcomment %}
     <script type="text/javascript">
         function getCookie(name) {
             var cookieValue = null;
@@ -474,33 +478,32 @@
 
             // Clone button
             $("#clone_this").click(function () {
-            $('#clone_this').html("Cloning...").removeClass('btn-warning btn-success').addClass('btn-primary');
-            var pk = $(this).attr('data-pk');
-            console.log("pk: " + pk);
-            var type = $(this).attr('data-type');
-            console.log("type: " + type);
-            $('#clone_spinner').addClass('fa fa-cog fa-spin');
+                $('#clone_this').html("Cloning...").removeClass('btn-warning btn-success').addClass('btn-primary');
+                var pk = $(this).attr('data-pk');
+                var type = $(this).attr('data-type');
+                var children = $('#clone_children').prop('checked');
+                $('#clone_spinner').addClass('fa fa-cog fa-spin');
 
-            $.ajax({
-                 type: "POST",
-                 url: "/clone/",
-                 data: {pk: pk, type: type},
-                 timeout: 9999999
-            }).done(function (response) {
-                $("#clone_this").addClass('btn-success').text("Success");
-                $("#clone_results").text(JSON.stringify(response, undefined, 2));
-                $('#clone_spinner').removeClass('fa fa-cog fa-spin');
-                if (response.hasOwnProperty('redirect_url')) {
-                    setTimeout(function () {
-                        window.location.href = response.redirect_url;
-                    }, 500);
-                }
-            }).fail(function (response) {
-                $("#clone_this").addClass('btn-warning').text("Failed");
-                $("#clone_results").text(JSON.stringify(response, undefined, 2));
-                $('#clone_spinner').removeClass('fa fa-cog fa-spin');
+                $.ajax({
+                     type: "POST",
+                     url: "/clone/",
+                     data: {pk: pk, type: type, children: children},
+                     timeout: 9999999
+                }).done(function (response) {
+                    $("#clone_this").addClass('btn-success').text("Success");
+                    $("#clone_results").text(JSON.stringify(response, undefined, 2));
+                    $('#clone_spinner').removeClass('fa fa-cog fa-spin');
+                    if (response.hasOwnProperty('redirect_url')) {
+                        setTimeout(function () {
+                            window.location.href = response.redirect_url;
+                        }, 500);
+                    }
+                }).fail(function (response) {
+                    $("#clone_this").addClass('btn-warning').text("Failed");
+                    $("#clone_results").text(JSON.stringify(response, undefined, 2));
+                    $('#clone_spinner').removeClass('fa fa-cog fa-spin');
+                });
             });
-        });
         });
     </script>
 {% endif %}

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -641,8 +641,11 @@ def publish(request):
 def clone(request):
     try:
         pk = int(request.POST.get('pk'))
-
         page_type = request.POST.get('type')
+        if request.POST.get('children') == 'true':
+            children = True
+        else:
+            children = False
 
         klass = globals()[page_type]
 
@@ -656,7 +659,7 @@ def clone(request):
         attrs = request.POST.get('attrs', {})
         exclude = request.POST.get('exclude', [])
 
-        duplicate = obj.clone(attrs=attrs, exclude=exclude)
+        duplicate = obj.clone(attrs=attrs, exclude=exclude, children=children)
 
         slack_message('slack/message.slack', {
             'message': 'cloned the %s %s'

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -87,7 +87,7 @@ class IDE(Page, RichText, CloneableMixin):
                 parent_cat = duplicate.categories.get(name=block.parent_cat.name)
                 block.clone(attrs={'title': block.title, 'slug': block.slug, 'parent': duplicate.page_ptr,
                                    'parent_ide': duplicate, 'parent_cat': parent_cat},
-                            exclude=['children', 'blocks'])
+                            exclude=['children', 'blocks'], children=True)
         return duplicate
 
 

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -64,7 +64,7 @@ class IDE(Page, RichText, CloneableMixin):
                 yield '\n'
                 logger.exception('Failed to publish %s' % self)
 
-    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[]):
+    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[], children=False):
 
         # If new title and/or slug weren't passed, update
         attrs['title'] = attrs.get('title', "%s (clone)" % self.title)
@@ -82,11 +82,12 @@ class IDE(Page, RichText, CloneableMixin):
 
         duplicate = super(IDE, self).clone(attrs=attrs, commit=commit,
                                            m2m_clone_reverse=m2m_clone_reverse, exclude=exclude)
-        for block in self.blocks.all():
-            parent_cat = duplicate.categories.get(name=block.parent_cat.name)
-            block.clone(attrs={'title': block.title, 'slug': block.slug, 'parent': duplicate.page_ptr,
-                               'parent_ide': duplicate, 'parent_cat': parent_cat},
-                        exclude=['children', 'blocks'])
+        if children:
+            for block in self.blocks.all():
+                parent_cat = duplicate.categories.get(name=block.parent_cat.name)
+                block.clone(attrs={'title': block.title, 'slug': block.slug, 'parent': duplicate.page_ptr,
+                                   'parent_ide': duplicate, 'parent_cat': parent_cat},
+                            exclude=['children', 'blocks'])
         return duplicate
 
 
@@ -209,7 +210,7 @@ class Block(Page, RichText, CloneableMixin):
             self.slug = slugify(self.title)
         super(Block, self).save(*args, **kwargs)
 
-    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[]):
+    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[], children=False):
 
         # If new title and/or slug weren't passed, update
         attrs['title'] = attrs.get('title', "%s (clone)" % self.title)
@@ -333,7 +334,7 @@ class Map(Page, RichText, CloneableMixin):
 
         super(Map, self).save(*args, **kwargs)
 
-    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[]):
+    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[], children=False):
 
         # If new title and/or slug weren't passed, update
         attrs['title'] = attrs.get('title', "%s (clone)" % self.title)

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -470,7 +470,8 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
         if children:
             if self.optional_lessons.count() > 0:
                 for lesson in self.optional_lessons.all():
-                    lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr, 'no_renumber': True})
+                    lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr, 'no_renumber': True},
+                                 children=True)
 
         # Keywords are a complex model and don't survive cloning, so we re-add here before returning the clone
         if self.keywords.count() > 0:

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -453,7 +453,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
 
         super(Lesson, self).save(*args, **kwargs)
 
-    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[]):
+    def clone(self, attrs={}, commit=True, m2m_clone_reverse=True, exclude=[], children=False):
         # If new title and/or slug weren't passed, update
         attrs['title'] = attrs.get('title', "%s (clone)" % self.title)
 
@@ -467,9 +467,10 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
         duplicate = super(Lesson, self).clone(attrs=attrs, commit=commit,
                                               m2m_clone_reverse=m2m_clone_reverse, exclude=exclude)
 
-        if self.optional_lessons.count() > 0:
-            for lesson in self.optional_lessons.all():
-                lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr, 'no_renumber': True})
+        if children:
+            if self.optional_lessons.count() > 0:
+                for lesson in self.optional_lessons.all():
+                    lesson.clone(attrs={'title': lesson.title, 'parent': duplicate.page_ptr, 'no_renumber': True})
 
         # Keywords are a complex model and don't survive cloning, so we re-add here before returning the clone
         if self.keywords.count() > 0:


### PR DESCRIPTION
The inital cloning feature assumed that we are always cloning with all children. In reality, it's more reasonable to clone the course empty and then pull in a clone of each unit one at a time as we are prepared to write them. This first step adds a checkbox to exclude children while cloning. Still ToDo:
* Pull out admin pane into a partial template
* Pull out admin js into a separate file
* Add dropdown to clone a unit into a different course