### PR TITLE
Custom forum link structuring per unit

### DIFF
--- a/curricula/migrations/0029_auto_20190110_1507.py
+++ b/curricula/migrations/0029_auto_20190110_1507.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('curricula', '0028_auto_20180711_1235'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='unit',
+            name='forum_url',
+            field=models.URLField(help_text=b'URL to forum, using % operators', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='unit',
+            name='forum_vars',
+            field=models.CharField(help_text=b'Tuple of properties to use in forum url', max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -269,6 +269,9 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
     show_calendar = models.BooleanField('Show Calendar', default=False, help_text='Show pacing guide calendar?')
     week_length = models.IntegerField('Days in a Week', default=5, blank=True, null=True,
                                       help_text='Controls the minimum lesson size in the pacing calendar.')
+    forum_url = models.URLField(blank=True, null=True, help_text='URL to forum, using % operators')
+    forum_vars = models.CharField(max_length=255, blank=True, null=True,
+                                  help_text='Tuple of properties to use in forum url')
     lesson_template_override = models.CharField(max_length=255, blank=True, null=True,
                                                 help_text='Override default lesson template,'
                                                           'eg curricula/pl_lesson.html')

--- a/lessons/migrations/0041_auto_20190110_1507.py
+++ b/lessons/migrations/0041_auto_20190110_1507.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lessons', '0040_resource_force_i18n'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='resource',
+            name='force_i18n',
+            field=models.BooleanField(default=False, help_text=b'\n        By default, only Resources that have been associated with a Lesson that\n        is itself being internationalized will be internationalized. However, we\n        occasionally want to be able to include Resources inline in markdown,\n        and those Resources will not be automatically synced.\n\n        Use this flag if for that or any other reason you would like to force a\n        Resource to be synced.\n    ', verbose_name=b'Force I18n'),
+        ),
+    ]

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -523,8 +523,14 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
 
     @property
     def forum_link(self):
-        # TODO: This assumes numbered units, which doesn't work for CSF - need to rework forum side of things
-        return "//forum.code.org/c/%s%d/" % (self.curriculum.get_canonical_slug(), self.unit.number)
+        if self.unit.forum_url:
+            if self.unit.forum_vars:
+                replacements = eval(self.unit.forum_vars)
+                return self.unit.forum_url % replacements
+            else:
+                return self.unit.forum_url
+        else:
+            return "//forum.code.org/"
 
     @property
     def feedback_link(self):


### PR DESCRIPTION
We're restructuring the teacher forum, which means that the current lesson forum link structure no longer works. This introduces a couple of new fields on the unit that allow for each unit to have a unique forum link structure to allow for differences between units where we want to direct to a lesson specific tag vs those that should link to a broader topic (like the PT prep unit).