### PR TITLE
fix automatic i18n sync

### DIFF
--- a/i18n/heroku_crowdin.sh
+++ b/i18n/heroku_crowdin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script exists solely to run heroku on crowdin. It's necessary for two
+# This script exists solely to run heroku on crowdin. It's necessary for three
 # reasons:
 #
 # First, the heroku apt buildpack doesn't correctly add the installed crowdin
@@ -10,9 +10,14 @@
 # path. This might be because the default-jre package expects
 # update-alternatives to set up the symlinks, but the actual cause is unclear.
 #
+# Third, the heroku scheduler sets $JAVA_TOOL_OPTIONS to some value that causes
+# this manual invocation of java to break (an environment state that is not
+# replicated when running scripts with `heroku run`), so we need to make sure
+# it's unset for this invocation.
+#
 # Either way, this script exists solely to get around that, and if we are ever
 # able to come up with a clean way to install the crowdin-cli and its
 # dependencies on heroku this can be removed.
 
 apt_dir="${BASH_SOURCE%/*}/../.apt/"
-$apt_dir/usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_dir/usr/local/bin/crowdin-cli.jar" "$@"
+JAVA_TOOL_OPTIONS= $apt_dir/usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_dir/usr/local/bin/crowdin-cli.jar" "$@"


### PR DESCRIPTION
We use [heroku scheduler](https://scheduler.heroku.com/dashboard) to automate the i18n sync, but it's been broken for a while now.

Turns out, this is because when running tasks through scheduler, the environmental variable `JAVA_TOOL_OPTIONS` is set to `-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1098 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=true -Djava.rmi.server.hostname=172.17.169.146 -Djava.rmi.server.port=1099`, which causes our (pretty damn hacky) custom java invocation of the crowdin cli to break.

Note that this environment variable is _not_ set when running commands with `heroku run`, which is why the manual sync has continued working.

As a quick fix, we simply specify in our hack that that environment variable not be set.

As a longer-term fix, we pray that https://github.com/heroku/heroku-buildpack-apt/pull/10 (or https://github.com/heroku/heroku-buildpack-apt/pull/39, which it appears will also help) will be merged soon so we can stop relying on this hack.