### PR TITLE
include Mezzanine 'content' field for all internationalized Page models

### DIFF
--- a/i18n/models.py
+++ b/i18n/models.py
@@ -115,4 +115,4 @@ class InternationalizablePage(Page, Internationalizable):
 
     @classmethod
     def internationalizable_fields(cls):
-        return ['title', 'description']
+        return ['title', 'description', 'content']


### PR DESCRIPTION
[Jira task](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=FND&view=detail&selectedIssue=FND-33)

I originally set out to translate `content` _instead of_ `description`, but upon closer investigation it turns out that we do in fact want to translate both of them.

Both content and description are fields provided by Mezzanine; by default, `description` will be generated from (and therefore be identical to) `content`, but it's possible to override that so the fields are distinct. We do actually take advantage of this optional feature in a couple cases, so we want to translate both fields just in case.

This does mean that any objects that do _not_ override `description` will upload identical strings for both content and description, but fortunately Crowdin takes care of duplicates for us so that shouldn't matter!