### PR TITLE
Fix documentation url routing

### DIFF
--- a/documentation/admin.py
+++ b/documentation/admin.py
@@ -42,6 +42,10 @@ class IDEAdmin(PageAdmin, VersionAdmin):
         }),
     )
 
+    # Override the "view on site" button to use local /documentation/ instead of docs.code.org path
+    def view_on_site(self, obj):
+        return '/documentation%s' % obj.get_absolute_url()
+
 
 class BlockForm(ModelForm):
     def __init__(self, *args, **kwargs):
@@ -94,6 +98,10 @@ class BlockAdmin(PageAdmin, VersionAdmin):
     formfield_overrides = {
         models.CharField: {'widget': Textarea(attrs={'rows': 2})},
     }
+
+    # Override the "view on site" button to use local /documentation/ instead of docs.code.org path
+    def view_on_site(self, obj):
+        return '/documentation%s' % obj.get_absolute_url()
 
 
 class MapAdmin(PageAdmin, VersionAdmin):

--- a/documentation/urls.py
+++ b/documentation/urls.py
@@ -6,8 +6,10 @@ from documentation import views
 urlpatterns = [
     multiurl(
         url(r'^(?P<slug>.*)/$', views.map_view, name="map_view"),
-        url(r'^(?P<slug>[-\w]+)/$', views.ide_view, name='ide_view'),
-        url(r'^(?P<ide_slug>[-\w]+)/(?P<slug>[-\w.]+)/$', views.block_view, name='block_view'),
-        url(r'^(?P<ide_slug>[-\w]+)/(?P<slug>[-\w.]+)/embed/$', views.embed_view, name='embed_view'),
+
+        # Assumes that all IDEs with docs end in lab to avoid routing conflicts with curriculum routes
+        url(r'^(?P<slug>[-\w]+lab)/$', views.ide_view, name='ide_view'),
+        url(r'^(?P<ide_slug>[-\w]+lab)/(?P<slug>[-\w.]+)/$', views.block_view, name='block_view'),
+        url(r'^(?P<ide_slug>[-\w]+lab)/(?P<slug>[-\w.]+)/embed/$', views.embed_view, name='embed_view'),
     )
 ]

--- a/documentation/views.py
+++ b/documentation/views.py
@@ -70,7 +70,11 @@ def page_view(request, parents, slug):
 
 def map_view(request, slug):
 
-    page = get_object_or_404(Map, slug=slug)
+    try:
+        page = Map.objects.get(slug=slug)
+    except Map.DoesNotExist:
+        raise ContinueResolving
+
     maps = Map.objects.filter(parent__slug='concepts')
 
     return render(request, 'documentation/map.html', {'map': page, 'maps': maps})


### PR DESCRIPTION
At some point recently the documentation routes stopped working. This was likely caused by some of the changes I made to move map levels into docs.code.org. This corrects for that issue as well as fixing a long standing bug that prevented the admin "view on site" button from using the correct local route for ides and blocks