### PR TITLE
White background for Mini Rubric Display

### DIFF
--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -366,6 +366,7 @@ html, body{
 
 .admonition.assessment {
     border: 2px solid #0094ca;
+    background-color: white;
 }
 
 .admonition.assessment > p.admonition-title {


### PR DESCRIPTION
Add a white background to display of mini rubric in code studio pull through because I forgot to commit this one line on my last PR (https://github.com/mrjoshida/curriculumbuilder/pull/70). Image of what it looks like can be found there.