### PR TITLE
Level icons now show the icon instead of a blank square

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -14,7 +14,7 @@
                     <!-- Header tabs -->
                     <ul>
                         <li class="chunk-header type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
-                            {{ level.display_name|default:level.name }} <span class="level-icon"></span>
+                            {{ level.display_name|default:level.name }} <span class="level-icon fa"></span>
                         </li>
                         {% if level.teacher_markdown %}
                         <li class="level-bubble type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
@@ -116,7 +116,7 @@
                         {% for level in chunk.levels %}
                             <li class="level-bubble type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
                                 <a href="#level-expando-{{ lesson.number }}-{{ level.position }}">
-                                    <span class="level-icon"></span>
+                                    <span class="level-icon fa"></span>
                                     {% if level.bonus_level %}
                                         Extra
                                     {% else %}

--- a/curricula/templates/curricula/partials/unit_calendar.html
+++ b/curricula/templates/curricula/partials/unit_calendar.html
@@ -16,7 +16,7 @@
                                  flex-basis: {{ unit.lesson_width }}%">
                         <span class="lesson-number">{{ lesson.number|stringformat:"02d" }}</span>
                         <a class="lesson-title" href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">{{ lesson.title }}</a>
-                        <span class="lesson-icon"></span>
+                        <span class="lesson-icon fa"></span>
                     </div>
                 {% endfor %}
             {% endfor %}

--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -793,11 +793,6 @@ th a:link, th a:visited, th a:hover, th a:active {
 }
 */
 
-.level-icon:before {
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: inherit;
-}
-
 /* Concept Levels */
 
 /* Text */
@@ -843,7 +838,7 @@ th a:link, th a:visited, th a:hover, th a:active {
 .type-Calc .level-icon:before,
 .level-icon:before
 {
-    content: '\f108';
+    content: "\f108";
 }
 
 

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -425,8 +425,6 @@ footer {
 .pacing-lesson.widget .lesson-icon:before,
 .pacing-lesson.research .lesson-icon:before,
 .pacing-lesson.external-tool .lesson-icon:before {
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: inherit;
     content: "\f108";
 }
 


### PR DESCRIPTION
### Before
<img width="1019" alt="Screen Shot 2019-03-06 at 1 04 13 PM" src="https://user-images.githubusercontent.com/208083/54243432-c9d3e580-44fe-11e9-9d2f-83c0680d423b.png">

### After
<img width="923" alt="Screen Shot 2019-03-12 at 7 39 54 PM" src="https://user-images.githubusercontent.com/208083/54243414-bd4f8d00-44fe-11e9-8211-b7831a9252a7.png">
