### PR TITLE
Remove some template translations

### DIFF
--- a/curricula/templates/curricula/partials/compare.html
+++ b/curricula/templates/curricula/partials/compare.html
@@ -1,4 +1,3 @@
-{% load i18n %}
 {% for record in compare_data %}
     {% for field_diff in record %}
         <h3>{% firstof field_diff.field.verbose_name field_diff.field.related_name %}{% if field_diff.is_related and not field_diff.follow %}<sup class="follow">*</sup>{% endif %}</h3>
@@ -10,15 +9,13 @@
     {% endfor %}
 {% endfor %}
 
-<h4>{% trans "Edit comment:" %}</h4>
+<h4>Edit comment:</h4>
 <blockquote>{{ version2.revision.comment|default:"(no comment exists)" }}</blockquote>
 
 {% if has_unfollowed_fields %}
-<h4 class="follow">{% trans "Note:" %}</h4>
+<h4 class="follow">Note:</h4>
 <p class="follow">
-    {% blocktrans %}
-        Fields/entries marked with <sup class="follow">*</sup> are not under reversion control.
-        It may be that not all marked information are correct.
-    {% endblocktrans %}
+    Fields/entries marked with <sup class="follow">*</sup> are not under reversion control.
+    It may be that not all marked information are correct.
 </p>
 {% endif %}

--- a/templates/accounts/account_login.html
+++ b/templates/accounts/account_login.html
@@ -1,17 +1,17 @@
 {% extends "accounts/account_form.html" %}
-{% load i18n future %}
+{% load future %}
 
 {% block main %}
 
 {% if request.user.is_authenticated %}
-    <p>{% trans "You're already logged in. If you'd like to log in as a different user, you'll need to log out first." %}</p>
+    <p>You're already logged in. If you'd like to log in as a different user, you'll need to log out first.</p>
 {% else %}
     {{ block.super }}
     {% url "signup" as signup_url %}
-    <p>{% blocktrans with request.GET.next as next %}If you don't have an account you can <a href="{{ signup_url }}?next={{ next }}">sign up</a> for one now.{% endblocktrans %}</p>
+    <p>{% with request.GET.next as next %}If you don't have an account you can <a href="{{ signup_url }}?next={{ next }}">sign up</a> for one now.{% endwith %}</p>
     {% url "mezzanine_password_reset" as password_reset_url %}
     {% url "profile_update" as profile_update_url %}
-    {% blocktrans %}<p>You can also <a href="{{ password_reset_url }}?next={{ profile_update_url }}">reset your password</a> if you've forgotten it.</p>{% endblocktrans %}</p>
+    <p>You can also <a href="{{ password_reset_url }}?next={{ profile_update_url }}">reset your password</a> if you've forgotten it.</p></p>
 {% endif %}
 
 {% endblock %}

--- a/templates/accounts/account_password_reset.html
+++ b/templates/accounts/account_password_reset.html
@@ -1,7 +1,6 @@
 {% extends "accounts/account_form.html" %}
-{% load i18n %}
 
 {% block main %}
 {{ block.super }}
-<p>{% trans "Enter your username or email address and you'll receive an email with a link you need to click, in order to log in and change your password." %}</p>
+<p>Enter your username or email address and you'll receive an email with a link you need to click, in order to log in and change your password.</p>
 {% endblock %}

--- a/templates/accounts/account_profile.html
+++ b/templates/accounts/account_profile.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n future mezzanine_tags accounts_tags %}
+{% load future mezzanine_tags accounts_tags %}
 
 {% block meta_title %}{{ profile_user|username_or:"get_full_name" }}{% endblock %}
 {% block title %}{{ profile_user|username_or:"get_full_name" }}{% endblock %}
@@ -15,7 +15,7 @@
 <div class="profile-image col-md-3">
     <img class="img-thumbnail" src="{% gravatar_url profile_user.email 128 %}">
     {% if profile_user == request.user %}
-    <br><a class="btn btn-primary" href="{% url "profile_update" %}">{% trans "Update profile" %}</a>
+    <br><a class="btn btn-primary" href="{% url "profile_update" %}">Update profile</a>
     {% endif %}
 </div>
 <div class="profile-content col-md-9">

--- a/templates/accounts/includes/user_panel.html
+++ b/templates/accounts/includes/user_panel.html
@@ -1,24 +1,24 @@
-{% load i18n future mezzanine_tags accounts_tags %}
+{% load future mezzanine_tags accounts_tags %}
 
 {% if request.user.is_authenticated %}
     <p>
-    {% trans "Logged in as: " %}
+    Logged in as:
     {% url "profile" request.user.username as profile_url %}
     {% if profile_url %}
         <a href="{{ profile_url }}">{{ request.user|username_or:"email" }}</a>
     </p>
         <a href="{% url "profile_update" %}" class="btn btn-default btn-sm btn-account">
-            <span class="glyphicon glyphicon-edit"></span> {% trans "Update profile" %}</a>
+            <span class="glyphicon glyphicon-edit"></span> Update profile</a>
     {% else %}
         <a href="{% url "profile_update" %}">{{ request.user|username_or:"email" }}</a>
     </p>
     {% endif %}
     <a href="{% url "logout" %}?next={{ request.path }}" class="btn btn-sm btn-danger btn-account">
-        <span class="glyphicon glyphicon-log-out"></span> {% trans "Log out" %}</a>
+        <span class="glyphicon glyphicon-log-out"></span> Log out</a>
 {% else %}
     <a href="{% url "login" %}?next={{ request.path }}" class="btn btn-default btn-sm btn-account">
-        <span class="glyphicon glyphicon-log-in"></span> {% trans "Log in" %}</a>
-    &nbsp;{% trans "or" %}&nbsp;
+        <span class="glyphicon glyphicon-log-in"></span> Log in</a>
+    &nbsp;or&nbsp;
     <a href="{% url "signup" %}?next={{ request.path }}" class="btn btn-default btn-sm btn-account">
-        <span class="glyphicon glyphicon-edit"></span> {% trans "Sign up" %}</a>
+        <span class="glyphicon glyphicon-edit"></span> Sign up</a>
 {% endif %}

--- a/templates/admin/change_form.html
+++ b/templates/admin/change_form.html
@@ -81,7 +81,7 @@
             <!-- Errors -->
             {% if errors %}
             <p class="errornote">
-                {% if count errors|length = 1 %}Please correct the error below.{% else %}Please correct the errors below.{% endif %}
+                {% if errors|length == 1 %}Please correct the error below.{% else %}Please correct the errors below.{% endif %}
             </p>
             <ul class="errorlist">{% for error in adminform.form.non_field_errors %}<li>{{ error }}</li>{% endfor %}</ul>
             {% endif %}

--- a/templates/admin/change_form.html
+++ b/templates/admin/change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load i18n admin_urls admin_static admin_modify %}
+{% load admin_urls admin_static admin_modify %}
 
 <!-- JAVASCRIPTS -->
 {% block javascripts %}
@@ -23,10 +23,10 @@
 {% block breadcrumbs %}{% if not is_popup %}
 <div class="breadcrumbs">
     {% url "admin:index" as admin_index_url %}
-    <a href="{{ admin_index_url }}">{% trans "Home" %}</a> &rsaquo;
+    <a href="{{ admin_index_url }}">Home</a> &rsaquo;
     <a href="../../">{{ app_label|capfirst|escape }}</a> &rsaquo;
     {% if has_change_permission %}<a href="../">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %} &rsaquo;
-    {% if add %}{% trans "Add" %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
+    {% if add %}Add {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
 </div>
 {% endif %}{% endblock %}
 
@@ -41,8 +41,8 @@
     <ul class="object-tools">
         {% block object-tools-items %}
             {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
-            <li><a href="{{ history_url }}">{% trans "History" %}</a></li>
-            {% if has_absolute_url %}<li><a href="{{ absolute_url }}" class="focus" target="_blank">{% trans "View on site" %}</a></li>{% endif%}
+            <li><a href="{{ history_url }}">History</a></li>
+            {% if has_absolute_url %}<li><a href="{{ absolute_url }}" class="focus" target="_blank">View on site</a></li>{% endif%}
         {% endblock %}
     </ul>
     {% endif %}
@@ -81,7 +81,7 @@
             <!-- Errors -->
             {% if errors %}
             <p class="errornote">
-                {% blocktrans count errors|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
+                {% if count errors|length = 1 %}Please correct the error below.{% else %}Please correct the errors below.{% endif %}
             </p>
             <ul class="errorlist">{% for error in adminform.form.non_field_errors %}<li>{{ error }}</li>{% endfor %}</ul>
             {% endif %}

--- a/templates/includes/editable_toolbar.html
+++ b/templates/includes/editable_toolbar.html
@@ -1,22 +1,22 @@
-{% load i18n staticfiles %}
+{% load staticfiles %}
 <div id="editable-toolbar" method="POST" action="{% url "admin:logout" %}">
     {% url "admin:index" as admin_index_url %}
     {% url "admin:logout" as admin_logout_url %}
     {% url "logout" as accounts_logout_url %}
     <a id="editable-toolbar-toggle" href="#"></a>
-    <a href="{{ editable_obj.get_admin_url|default:admin_index_url }}">{% trans "Admin" %}</a>
+    <a href="{{ editable_obj.get_admin_url|default:admin_index_url }}">Admin</a>
     {% if lesson %}
-        <a href="{{ lesson.get_admin_url }}">{% trans "Lesson Admin" %}</a>
+        <a href="{{ lesson.get_admin_url }}">Lesson Admin</a>
     {% elif unit %}
-        <a href="{{ unit.get_admin_url }}">{% trans "Unit Admin" %}</a>
+        <a href="{{ unit.get_admin_url }}">Unit Admin</a>
     {% elif curriculum %}
-        <a href="{{ curriculum.get_admin_url }}">{% trans "Curriculum Admin" %}</a>
+        <a href="{{ curriculum.get_admin_url }}">Curriculum Admin</a>
     {% elif code_block %}
-        <a href="{{ code_block.get_admin_url }}">{% trans "Code Block Admin" %}</a>
+        <a href="{{ code_block.get_admin_url }}">Code Block Admin</a>
     {% elif ide %}
-        <a href="{{ ide.get_admin_url }}">{% trans "IDE Admin" %}</a>
+        <a href="{{ ide.get_admin_url }}">IDE Admin</a>
     {% endif %}
-    <a href="{{ accounts_logout_url|default:admin_logout_url }}?{{ REDIRECT_FIELD_NAME }}={{ request.path }}">{% trans "Log out" %}</a>
+    <a href="{{ accounts_logout_url|default:admin_logout_url }}?{{ REDIRECT_FIELD_NAME }}={{ request.path }}">Log out</a>
 </div>
 
 <img id="editable-loading" src="{% static "mezzanine/img/loadingAnimation.gif" %}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load i18n %}
 
 {% block meta_title %}{% trans "Home" %}{% endblock %}
 {% block title %}{% trans "Home" %}{% endblock %}
@@ -9,7 +8,6 @@
 {% endblock %}
 
 {% block main %}
-{% blocktrans %}
 <h2>Congratulations!</h2>
 <p>
     Welcome to your new Mezzanine powered website.
@@ -24,5 +22,4 @@
     <li><a href="http://mezzanine.jupo.org/docs/configuration.html#default-settings">Full list of settings</a></li>
     <li><a href="http://mezzanine.jupo.org/docs/deployment.html">Deploying to a production server</a></li>
 </ul>
-{% endblocktrans %}
 {% endblock %}


### PR DESCRIPTION
This PR removes the translation tags from a number of strings. I've manually tested all the ones I could find, but I couldn't always figure out the path to these views (I wouldn't be surprised if some of these aren't used).