### PR TITLE
Make the i18n sync slack logs quieter and more informative

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -119,18 +119,19 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin):
     def jackfrost_can_build(self):
         return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
 
-    def publish(self, children=False):
+    def publish(self, children=False, silent=False):
         if children:
             for unit in self.units:
-                for result in unit.publish(True):
+                for result in unit.publish(children=True):
                     yield result
         if self.jackfrost_can_build():
             try:
                 read, written = build_page_for_obj(Curriculum, self)
-                slack_message('slack/message.slack', {
-                    'message': 'published %s %s' % (self.content_model, self.title),
-                    'color': '#00adbc'
-                })
+                if not silent:
+                    slack_message('slack/message.slack', {
+                        'message': 'published %s %s' % (self.content_model, self.title),
+                        'color': '#00adbc'
+                    })
                 yield json.dumps(written)
                 yield '\n'
             except Exception, e:
@@ -138,14 +139,15 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin):
                 yield '\n'
                 logger.exception('Failed to publish %s' % self)
 
-    def publish_pdfs(self, *args, **kwargs):
+    def publish_pdfs(self, silent=False, *args, **kwargs):
         if self.jackfrost_can_build():
             try:
                 read, written = build_single(self.get_pdf_url())
-                slack_message('slack/message.slack', {
-                    'message': 'published %s %s' % (self.content_model, self.title),
-                    'color': '#00adbc'
-                })
+                if not silent:
+                    slack_message('slack/message.slack', {
+                        'message': 'published %s %s' % (self.content_model, self.title),
+                        'color': '#00adbc'
+                    })
                 yield json.dumps(written)
                 yield '\n'
             except Exception, e:
@@ -376,7 +378,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
     def jackfrost_can_build(self):
         return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required and not self.curriculum.login_required
 
-    def publish(self, children=False):
+    def publish(self, children=False, silent=False):
         if children:
             for lesson in self.lesson_set.all():
                 for result in lesson.publish():
@@ -385,10 +387,11 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
             for url in self.jackfrost_urls():
                 try:
                     read, written = build_single(url)
-                    slack_message('slack/message.slack', {
-                        'message': 'published %s %s %s' % (self.content_model, self.title, url),
-                        'color': '#00adbc'
-                    })
+                    if not silent:
+                        slack_message('slack/message.slack', {
+                            'message': 'published %s %s %s' % (self.content_model, self.title, url),
+                            'color': '#00adbc'
+                        })
                     yield json.dumps(written)
                     yield '\n'
                 except Exception, e:
@@ -396,15 +399,16 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
                     yield '\n'
                     logger.exception('Failed to publish %s' % self)
 
-    def publish_pdfs(self, *args, **kwargs):
+    def publish_pdfs(self, silent=False, *args, **kwargs):
         if self.jackfrost_can_build():
             for url in self.pdf_urls():
                 try:
                     read, written = build_single(url)
-                    slack_message('slack/message.slack', {
-                        'message': 'published PDF for %s %s' % (self.content_model, self.title),
-                        'color': '#00adbc'
-                    })
+                    if not silent:
+                        slack_message('slack/message.slack', {
+                            'message': 'published PDF for %s %s' % (self.content_model, self.title),
+                            'color': '#00adbc'
+                        })
                     yield json.dumps(written)
                     yield '\n'
                 except Exception, e:
@@ -412,15 +416,16 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
                     yield '\n'
                     logger.exception('Failed to publish PDF %s' % self)
 
-    def publish_json(self, *args, **kwargs):
+    def publish_json(self, silent=False, *args, **kwargs):
         if self.jackfrost_can_build():
             url = self.get_json_url()
             try:
                 read, written = build_single(url)
-                slack_message('slack/message.slack', {
-                    'message': 'published JSON for %s %s' % (self.content_model, self.title),
-                    'color': '#00adbc'
-                })
+                if not silent:
+                    slack_message('slack/message.slack', {
+                        'message': 'published JSON for %s %s' % (self.content_model, self.title),
+                        'color': '#00adbc'
+                    })
                 yield json.dumps(written)
                 yield '\n'
             except Exception, e:

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -700,7 +700,7 @@ def old_publish(request):
         if request.POST.get('pdf') == 'true':
             payload = obj.publish_pdfs()
         else:
-            payload = obj.publish(children)
+            payload = obj.publish(children=children)
 
         attachments = [
             {

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -45,7 +45,7 @@ class IDE(Page, RichText, CloneableMixin):
     def jackfrost_can_build(self):
         return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
 
-    def publish(self, children=False):
+    def publish(self, children=False, silent=False):
         if children:
             for block in self.blocks.all():
                 for result in block.publish():
@@ -53,10 +53,11 @@ class IDE(Page, RichText, CloneableMixin):
         if self.jackfrost_can_build():
             try:
                 read, written = build_page_for_obj(IDE, self)
-                slack_message('slack/message.slack', {
-                    'message': 'published %s %s' % (self.content_model, self.title),
-                    'color': '#00adbc'
-                })
+                if not silent:
+                    slack_message('slack/message.slack', {
+                        'message': 'published %s %s' % (self.content_model, self.title),
+                        'color': '#00adbc'
+                    })
                 yield json.dumps(written)
                 yield '\n'
             except Exception, e:
@@ -167,14 +168,15 @@ class Block(Page, RichText, CloneableMixin):
     def jackfrost_can_build(self):
         return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
 
-    def publish(self, children=False):
+    def publish(self, children=False, silent=False):
         if self.jackfrost_can_build():
             try:
                 read, written = build_page_for_obj(Block, self)
-                slack_message('slack/message.slack', {
-                    'message': 'published %s %s' % (self.content_model, self.title),
-                    'color': '#00adbc'
-                })
+                if not silent:
+                    slack_message('slack/message.slack', {
+                        'message': 'published %s %s' % (self.content_model, self.title),
+                        'color': '#00adbc'
+                    })
                 yield json.dumps(written)
                 yield '\n'
             except Exception, e:
@@ -314,7 +316,7 @@ class Map(Page, RichText, CloneableMixin):
     def jackfrost_can_build(self):
         return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
 
-    def publish(self, children=False):
+    def publish(self, children=False, silent=False):
         if children:
             for page in self.children.all():
                 for result in page.map.publish(children=children):
@@ -322,10 +324,11 @@ class Map(Page, RichText, CloneableMixin):
         if self.jackfrost_can_build():
             try:
                 read, written = build_page_for_obj(Map, self)
-                slack_message('slack/message.slack', {
-                    'message': 'published %s %s' % (self.content_model, self.title),
-                    'color': '#00adbc'
-                })
+                if not silent:
+                    slack_message('slack/message.slack', {
+                        'message': 'published %s %s' % (self.content_model, self.title),
+                        'color': '#00adbc'
+                    })
                 yield json.dumps(written)
                 yield '\n'
             except Exception, e:

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -9,26 +9,34 @@ from django.utils import translation
 from i18n.models import Internationalizable
 from i18n.utils import print_clear
 
+from django_slack import slack_message
+
+def should_publish_model(model):
+    is_internationalizable = issubclass(model, Internationalizable)
+    is_not_proxy = not model._meta.proxy
+    has_publish_operation = hasattr(model, 'publish') or hasattr(model, 'publish_pdfs')
+    return is_internationalizable and is_not_proxy and has_publish_operation
+
+def log(message):
+    print(message)
+    slack_message('slack/message.slack', {
+        'message': message
+    })
+
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        print("Publishing translated content")
-        for model in django.apps.apps.get_models():
-            is_internationalizable = issubclass(model, Internationalizable)
-            is_not_proxy = not model._meta.proxy
-            if not (is_internationalizable and is_not_proxy):
-                continue
+        log("Publishing translated content")
+        models = [model for model in django.apps.apps.get_models() if should_publish_model(model)]
+        log("Models to publish: %s" % ', '.join(model.__name__ for model in models))
 
+        for model_index, model in enumerate(models):
             name = model.__name__
-
-            if not hasattr(model, 'publish') and not hasattr(model, 'publish_pdfs'):
-                print("%s - skipping (no publish operation available)" % name)
-                continue
-
-            print_clear("%s - loading" % name)
+            log("Publishing %s (%s/%s)" % (name, model_index + 1, len(models)))
             objects = model.get_i18n_objects()
             total = objects.count()
+            success_count = 0
+
             for index, obj in enumerate(objects.all()):
-                print_clear("%s - publishing %s/%s" % (name, index, total))
                 if not obj.should_be_translated:
                     continue
 
@@ -39,9 +47,10 @@ class Command(BaseCommand):
 
                     translation.activate(language_code)
                     if hasattr(obj, 'publish'):
-                        list(obj.publish())
+                        list(obj.publish(silent=True))
                     if hasattr(obj, 'publish_pdfs'):
-                        list(obj.publish_pdfs())
+                        list(obj.publish_pdfs(silent=True))
+                success_count += 1
 
                 translation.activate(original_lang)
-            print_clear("%s - finished" % name, end='\n')
+            log("%s/%s %s objects published" % (success_count, total, name))

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -427,15 +427,16 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
 
         return can_build
 
-    def publish(self, children=False):
+    def publish(self, children=False, silent=False):
         if self.jackfrost_can_build():
             for url in self.jackfrost_urls():
                 try:
                     read, written = build_single(url)
-                    slack_message('slack/message.slack', {
-                        'message': 'published %s %s' % (self.content_model, self.title),
-                        'color': '#00adbc'
-                    })
+                    if not silent:
+                        slack_message('slack/message.slack', {
+                            'message': 'published %s %s' % (self.content_model, self.title),
+                            'color': '#00adbc'
+                        })
                     yield json.dumps(written)
                     yield '\n'
                 except Exception, e:


### PR DESCRIPTION
First step in adding better error logging to the i18n sync: clean up the existing logs.

Right now, the i18n sync is _super_ noisy in slack, because every single piece of content published (in every single language) gets logged. This adds some logic to the publish operation to conditionally silent logging, and uses that in the i18n sync to only log high-level overviews of what gets logged. This should make the logs more useful to actually parse.

Next step: add error detection and logging.