### PR TITLE
make the i18n sync down a little less verbose

### DIFF
--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -33,6 +33,7 @@ class Command(BaseCommand):
                 filename = os.path.basename(source_path)
                 translation_path = os.path.join(translations_dir, locale, filename)
                 if not os.path.exists(translation_path):
+                    log("Could not find %s to restore" % translation_path)
                     continue
                 plugins_path = os.path.join(I18nFileWrapper.i18n_dir(), "config", "plugins", "*.js")
                 plugins = ",".join(glob.glob(plugins_path))
@@ -49,6 +50,7 @@ class Command(BaseCommand):
         for locale in get_non_english_language_codes():
             for translation_path in glob.glob(os.path.join(translations_dir, locale, '*')):
                 if not os.path.exists(translation_path):
+                    log("Could not find %s to upload" % translation_path)
                     continue
                 filename = os.path.basename(translation_path)
                 with open(translation_path) as translation_file:

--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -3,10 +3,9 @@ import glob
 import os
 import subprocess
 
-from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from i18n.management.utils import log
+from i18n.management.utils import log, get_non_english_language_codes
 from i18n.utils import I18nFileWrapper
 
 
@@ -23,19 +22,20 @@ class Command(BaseCommand):
             "download"
         ])
 
+        source_paths = glob.glob(os.path.join(source_dir, '*'))
+        log("Restoring and uploading %s" % ", ".join(map(os.path.basename, source_paths)))
+        log("For %s" % ", ".join(get_non_english_language_codes()))
+
         # Restore translations from source
         log("Restoring redacted translations from source")
-        for locale, _ in settings.LANGUAGES:
-            if locale == settings.LANGUAGE_CODE:
-                continue
-            for source_path in glob.glob(os.path.join(source_dir, '*')):
+        for locale in get_non_english_language_codes():
+            for source_path in source_paths:
                 filename = os.path.basename(source_path)
                 translation_path = os.path.join(translations_dir, locale, filename)
                 if not os.path.exists(translation_path):
                     continue
                 plugins_path = os.path.join(I18nFileWrapper.i18n_dir(), "config", "plugins", "*.js")
                 plugins = ",".join(glob.glob(plugins_path))
-                log("%s - restoring %s" % (locale, filename))
                 subprocess.call([
                     'restore',
                     '-s', source_path,
@@ -43,19 +43,14 @@ class Command(BaseCommand):
                     '-o', translation_path,
                     '-p', plugins
                 ])
-            log("%s - finished" % locale)
 
         # Upload restored translation data to s3
         log("Uploading restored translations to S3")
-        for locale, _ in settings.LANGUAGES:
-            if locale == settings.LANGUAGE_CODE:
-                continue
+        for locale in get_non_english_language_codes():
             for translation_path in glob.glob(os.path.join(translations_dir, locale, '*')):
                 if not os.path.exists(translation_path):
                     continue
                 filename = os.path.basename(translation_path)
-                log("%s - uploading %s" % (locale, filename))
                 with open(translation_path) as translation_file:
                     dest_path = os.path.join('translations', locale, filename)
                     I18nFileWrapper.storage().save(dest_path, translation_file)
-            log("%s - finished" % locale)

--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -3,6 +3,8 @@ Helper methods for use during the i18n sync process
 """
 from django_slack import slack_message
 
+from django.conf import settings
+
 from i18n.models import Internationalizable
 
 
@@ -16,6 +18,17 @@ def should_sync_model(model):
     is_internationalizable = issubclass(model, Internationalizable)
     is_not_proxy = not model._meta.proxy # pylint: disable=protected-access
     return is_internationalizable and is_not_proxy
+
+
+def get_non_english_language_codes():
+    """
+    Retrieve all languages codes (ie "es-mx") for languages we need to process
+    in the i18n sync.
+    """
+    return [
+        locale for locale, _ in settings.LANGUAGES
+        if not locale == settings.LANGUAGE_CODE
+    ]
 
 
 def log(message):


### PR DESCRIPTION
Log the lists of translation files and languages individually, rather than logging the cross product.

Also add logging for missing files.