### PR TITLE
Don't try to publish PDFs for Curriculum

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -139,22 +139,6 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin):
                 yield '\n'
                 logger.exception('Failed to publish %s' % self)
 
-    def publish_pdfs(self, silent=False, *args, **kwargs):
-        if self.jackfrost_can_build():
-            try:
-                read, written = build_single(self.get_pdf_url())
-                if not silent:
-                    slack_message('slack/message.slack', {
-                        'message': 'published %s %s' % (self.content_model, self.title),
-                        'color': '#00adbc'
-                    })
-                yield json.dumps(written)
-                yield '\n'
-            except Exception, e:
-                yield json.dumps(e.message)
-                yield '\n'
-                logger.exception('Failed to publish PDF for %s' % self)
-
     def get_standards(self):
         # ToDo: run the standards queries once and place all the querysets in a dict for later use
         if Chapter.objects.filter(parent__unit__curriculum=self).count() > 0:

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import translation
 
-from i18n.management.utils import log, should_publish_pdf, should_sync_model
+from i18n.management.utils import log, should_sync_model
 
 class Command(BaseCommand):
     def should_publish_model(self, model):
@@ -42,7 +42,7 @@ class Command(BaseCommand):
                     translation.activate(language_code)
                     if hasattr(obj, 'publish'):
                         list(obj.publish(silent=True))
-                    if should_publish_pdf(obj):
+                    if hasattr(obj, 'publish_pdfs'):
                         list(obj.publish_pdfs(silent=True))
                 success_count += 1
 

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -7,8 +7,6 @@ from django.utils import translation
 
 from i18n.management.utils import log, should_publish_pdf, should_sync_model
 
-import sys
-
 class Command(BaseCommand):
     def should_publish_model(self, model):
         model_has_publish_operation = hasattr(model, 'publish') or hasattr(model, 'publish_pdfs')

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
 
         language_codes = [
             language_code for language_code, _ in settings.LANGUAGES
-            if language_code != settings.LANGUAGE_CODE and language_code != settings.LANGUAGE_CODE_DO_TRANSLATION
+            if language_code != settings.LANGUAGE_CODE
         ]
         log("Languages to publish: %s" % ', '.join(language_codes))
 

--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -7,6 +7,8 @@ from django.conf import settings
 
 from i18n.models import Internationalizable
 
+from curricula.models import Curriculum
+
 
 def should_sync_model(model):
     """
@@ -19,6 +21,8 @@ def should_sync_model(model):
     is_not_proxy = not model._meta.proxy # pylint: disable=protected-access
     return is_internationalizable and is_not_proxy
 
+def should_publish_pdf(obj):
+    return hasattr(obj, 'publish_pdfs') and not isinstance(obj, Curriculum)
 
 def get_non_english_language_codes():
     """

--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -7,8 +7,6 @@ from django.conf import settings
 
 from i18n.models import Internationalizable
 
-from curricula.models import Curriculum
-
 
 def should_sync_model(model):
     """
@@ -20,6 +18,7 @@ def should_sync_model(model):
     is_internationalizable = issubclass(model, Internationalizable)
     is_not_proxy = not model._meta.proxy # pylint: disable=protected-access
     return is_internationalizable and is_not_proxy
+
 
 def get_non_english_language_codes():
     """

--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -21,9 +21,6 @@ def should_sync_model(model):
     is_not_proxy = not model._meta.proxy # pylint: disable=protected-access
     return is_internationalizable and is_not_proxy
 
-def should_publish_pdf(obj):
-    return hasattr(obj, 'publish_pdfs') and not isinstance(obj, Curriculum)
-
 def get_non_english_language_codes():
     """
     Retrieve all languages codes (ie "es-mx") for languages we need to process


### PR DESCRIPTION
1. They're broken for English and non-English
2. They don't seem to be used anywhere (and there's no UI element that directs you to them, unlike the courses)

There are still some courses where PDF generation fails (Course D and Express in particular) due to a faulty link in some content. However, the publish command does continue locally, unlike on the Dyno, and I have a theory it's due to a timeout as it would try to publish CSF-1718 next, which is *large*.

~This PR also prevents us from syncing in-tl, which I don't believe we need to be generating.~