### PR TITLE
Only restore redacted content

### DIFF
--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -1,37 +1,42 @@
-# pylint: disable=missing-docstring,too-few-public-methods,no-self-use
+# pylint: disable=missing-docstring,no-self-use
 import glob
 import os
 import subprocess
 
 from django.core.management.base import BaseCommand
 
-from i18n.management.utils import log, get_non_english_language_codes
+from i18n.management.utils import log, get_non_english_language_codes, get_models_to_sync
 from i18n.utils import I18nFileWrapper
 
 
 class Command(BaseCommand):
-    def handle(self, *args, **options):
-        source_dir = os.path.join(I18nFileWrapper.static_dir(), 'source')
-        translations_dir = os.path.join(I18nFileWrapper.static_dir(), 'translations')
+    source_dir = os.path.join(I18nFileWrapper.static_dir(), 'source')
+    translations_dir = os.path.join(I18nFileWrapper.static_dir(), 'translations')
 
-        # Download translations from crowdin
-        log("I18n Sync Step 3 of 4: Download translations from Crowdin")
+    def download_translations(self):
+        """Download translations from crowdin"""
         subprocess.call([
             os.path.join(I18nFileWrapper.i18n_dir(), 'heroku_crowdin.sh'),
             "--config", os.path.join(I18nFileWrapper.i18n_dir(), "config", "crowdin.yml"),
             "download"
         ])
 
-        source_paths = glob.glob(os.path.join(source_dir, '*'))
-        log("Restoring and uploading %s" % ", ".join(map(os.path.basename, source_paths)))
+    def restore_translations(self):
+        """Restore translations from source"""
+        # Only redacted content should be restored; otherwise, we're running a
+        # markdown formatter over content that may or may not be markdown.
+        models_to_restore = [
+            model for model in get_models_to_sync()
+            if model.should_redact()
+        ]
+        log("Restoring redacted translations for %s" %
+            ', '.join(model.__name__ for model in models_to_restore))
         log("For %s" % ", ".join(get_non_english_language_codes()))
-
-        # Restore translations from source
-        log("Restoring redacted translations from source")
         for locale in get_non_english_language_codes():
-            for source_path in source_paths:
-                filename = os.path.basename(source_path)
-                translation_path = os.path.join(translations_dir, locale, filename)
+            for model in models_to_restore:
+                filename = model.__name__ + ".json"
+                source_path = os.path.join(self.source_dir, filename)
+                translation_path = os.path.join(self.translations_dir, locale, filename)
                 if not os.path.exists(translation_path):
                     log("Could not find %s to restore" % translation_path)
                     continue
@@ -45,10 +50,13 @@ class Command(BaseCommand):
                     '-p', plugins
                 ])
 
-        # Upload restored translation data to s3
-        log("Uploading restored translations to S3")
+    def upload_translations(self):
+        """Upload restored translation data to s3"""
+        source_paths = glob.glob(os.path.join(self.source_dir, '*'))
+        log("Uploading restored translations to S3: %s" %
+            ", ".join(map(os.path.basename, source_paths)))
         for locale in get_non_english_language_codes():
-            for translation_path in glob.glob(os.path.join(translations_dir, locale, '*')):
+            for translation_path in glob.glob(os.path.join(self.translations_dir, locale, '*')):
                 if not os.path.exists(translation_path):
                     log("Could not find %s to upload" % translation_path)
                     continue
@@ -56,3 +64,9 @@ class Command(BaseCommand):
                 with open(translation_path) as translation_file:
                     dest_path = os.path.join('translations', locale, filename)
                     I18nFileWrapper.storage().save(dest_path, translation_file)
+
+    def handle(self, *args, **options):
+        log("I18n Sync Step 3 of 4: Download and process translations")
+        self.download_translations()
+        self.restore_translations()
+        self.upload_translations()


### PR DESCRIPTION
Follow-up to https://github.com/mrjoshida/curriculumbuilder/pull/85

The goal of that PR was to only redact content we know we want to be
redacted, to prevent applying markdown formatting to things we don't
want to treat as markdown (like Resource URLs). Unfortunately, even
though we're only _redacting_ the things we know we want to process,
we're still _restoring_ everything, which applies the same formatting as
redaction.

Extending the requirement to both redaction and restoration should
actually fix the problem.

Also broke the `handle` method up into individual helper methods, since
it was getting too long.