### PR TITLE
Remove translation tags in templates/generic/includes and templates/pages/menus

### DIFF
--- a/templates/generic/includes/rating.html
+++ b/templates/generic/includes/rating.html
@@ -1,10 +1,10 @@
-{% load mezzanine_tags rating_tags i18n future %}
+{% load mezzanine_tags rating_tags future %}
 
 <span id="rating-{{ rating_object.id }}">
     {% if rating_average %}
-    {% trans "Current rating" %}: {{ rating_average|floatformat }}
+    Current rating: {{ rating_average|floatformat }}
     {% else %}
-    {% trans "Currently unrated" %}
+    Currently unrated
     {% endif %}
 </span>
 
@@ -14,7 +14,7 @@
     {% csrf_token %}
     {% endnevercache %}
     <ul class="radio radio-inline">{{ rating_form.as_ul }}</ul>
-    <input type="submit" class="btn btn-default btn-sm" value="{% trans "Rate" %}"
+    <input type="submit" class="btn btn-default btn-sm" value="Rate"
         onclick="return $(this.form).find('input:checked').length == 1;">
 </form>
 {% endif %}

--- a/templates/includes/editable_form.html
+++ b/templates/includes/editable_form.html
@@ -1,4 +1,3 @@
-{% load i18n %}
 {% load field_type %}
 
 {# Edit form #}
@@ -15,8 +14,8 @@
         {% endif %}
     </div>
     {% endfor %}
-    <input type="submit" value="{% trans "Save" %}" class="btn btn-primary btn-lg">
-    <input type="button" value="{% trans "Cancel" %}" class="btn btn-default btn-lg">
+    <input type="submit" value="Save" class="btn btn-primary btn-lg">
+    <input type="button" value="Cancel" class="btn btn-default btn-lg">
 </form>
 
 {# Original content wrapped in span #}
@@ -24,7 +23,7 @@
 
 {# Edit link #}
 <a style="visibility:hidden;" class="editable-link" href="#"
-    rel="#{{ editable_form.uuid }}">{% trans "Edit" %}</a>
+    rel="#{{ editable_form.uuid }}">Edit</a>
 
 {# Edit highlight #}
 <div style="visibility:hidden;" class="editable-highlight"></div>

--- a/templates/includes/form_errors.html
+++ b/templates/includes/form_errors.html
@@ -1,11 +1,9 @@
-{% load i18n %}
-
 {% if form.non_field_errors or form.errors %}
 <div class="form-errors">
     {% for error in form.non_field_errors %}
     <div class="alert alert-danger non-field-error">{{ error }}</div>
     {% empty %}
-    <div class="alert alert-danger field-error">{% trans "Please correct the errors below." %}</div>
+    <div class="alert alert-danger field-error">Please correct the errors below.</div>
     {% endfor %}
 </div>
 {% endif %}

--- a/templates/includes/pagination.html
+++ b/templates/includes/pagination.html
@@ -1,10 +1,8 @@
-{% load i18n %}
-
 {% if current_page.has_previous or current_page.has_next %}
 <ul class="pagination">
 
 <li class="page-info">
-    <span>{% trans "Page" %} {{ current_page.number }} {% trans "of" %} {{ current_page.paginator.num_pages }}</span>
+    <span>Page {{ current_page.number }} of {{ current_page.paginator.num_pages }}</span>
 </li>
 <li class="prev previous{% if not current_page.has_previous %} disabled{% endif %}">
     <a{% if current_page.has_previous %} href="?{{ page_var }}={{ current_page.previous_page_number }}{% if querystring %}&{{ querystring }}{% endif %}"{% endif %}>&larr;</a>

--- a/templates/includes/search_form.html
+++ b/templates/includes/search_form.html
@@ -2,7 +2,7 @@
 <form action="{% url "search" %}" class="navbar-form navbar-right" role="search">
 
 <div class="form-group">
-    <input class="form-control" placeholder="{% trans "Search" %}" type="text" name="q" value="{{ request.REQUEST.q }}">
+    <input class="form-control" placeholder="Search" type="text" name="q" value="{{ request.REQUEST.q }}">
 </div>
 
 {% if search_model_choices %}
@@ -11,7 +11,7 @@
     {% else %}
     <div class="form-group">
     <select class="form-control" name="type">
-        <option value="">{% trans "Everything" %}</option>
+        <option value="">Everything</option>
         {% for verbose_name, model in search_model_choices %}
         <option value="{{ model }}"
             {% if model == request.REQUEST.type  %}selected{% endif %}>
@@ -23,6 +23,6 @@
     {% endif %}
 {% endif %}
 
-<input type="submit" class="btn btn-default" value="{% trans "Go" %}">
+<input type="submit" class="btn btn-default" value="Go">
 
 </form>

--- a/templates/pages/menus/admin.html
+++ b/templates/pages/menus/admin.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future staticfiles %}
+{% load pages_tags future staticfiles %}
 
 <ol>
     {% for page in page_branch %}
@@ -33,7 +33,7 @@
             </span>
             {% if page.perms.add and page.content_model != 'block' %}
                 <select class="addlist" id="addlink-{{ page.id }}">
-                    <option value="">{% trans "Add" %} ...</option>
+                    <option value="">Add ...</option>
                         {% if page.content_model == 'curriculum' %}
                             <option value="/admin/documentation/map/add/?parent={{ page.id }}">
                                 Map

--- a/templates/pages/menus/dropdown.html
+++ b/templates/pages/menus/dropdown.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load future pages_tags %}
 {% spaceless %}
 {% if page_branch_in_menu %}
 
@@ -7,7 +7,7 @@
     {% for page in page_branch %}
     {% if not has_home and page.is_primary and forloop.first %}
     <li{% if on_home %} class="active"{% endif %} id="dropdown-menu-home">
-        <a href="{% url "home" %}">{% trans "Home" %}</a>
+        <a href="{% url "home" %}">Home</a>
     </li>
     {% endif %}
     {% if page.in_menu %}

--- a/templates/pages/menus/footer_tree.html
+++ b/templates/pages/menus/footer_tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load future pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}
@@ -8,7 +8,7 @@
     {% if not has_home and page.is_primary and forloop.first %}
 	<li class="first{% if on_home %} active{% endif %}"
         id="footer-tree-menu-home">
-	    <a href="{% url "home" %}">{% trans "Home" %}</a>
+	    <a href="{% url "home" %}">Home</a>
 	</li>
 	{% endif %}
 

--- a/templates/pages/menus/mobile.html
+++ b/templates/pages/menus/mobile.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load future pages_tags %}
 
 {% spaceless %}
 {% if page_branch %}
@@ -7,7 +7,7 @@
 	{% if not has_home and page.is_primary and forloop.first %}
 	<ul class="mobile-menu">
 		<li><a class="home" href="{% url "home" %}"
-			   id="tree-menu-home">{% trans "Home" %}</a></li>
+			   id="tree-menu-home">Home</a></li>
     {% endif %}
 
 		{% if page.is_current_or_ascendant and not page.is_current_child %}

--- a/templates/pages/menus/primary.html
+++ b/templates/pages/menus/primary.html
@@ -1,11 +1,11 @@
-{% load pages_tags i18n future %}
+{% load pages_tags future %}
 
 {% spaceless %}
 <ul id="primary-menu" class="nav pull-right">
     {% for page in page_branch %}
     {% if not has_home and page.is_primary and forloop.first %}
     <li id="primary-menu-home" class="first{% if on_home %} active{% endif %}">
-        <a href="{% url "home" %}">{% trans "Home" %}</a>
+        <a href="{% url "home" %}">Home</a>
     </li>
     {% endif %}
     {% if page.in_menu %}

--- a/templates/pages/menus/tree.html
+++ b/templates/pages/menus/tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load future pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}
@@ -6,7 +6,7 @@
   {% for page in page_branch %}
   {% if not has_home and page.is_primary and forloop.first %}
   <li{% if on_home %} class="active"{% endif %} id="tree-menu-home">
-    <a href="{% url "home" %}">{% trans "Home" %}</a>
+    <a href="{% url "home" %}">Home</a>
   </li>
   {% endif %}
   {% if page.in_menu %}


### PR DESCRIPTION
I've played around on the site a bit and haven't seen any issues. These are all straightforward tag changes.