### PR TITLE
Code Studio Pull Through: Fix mini rubrics showing up on non-mini-rubric levels.

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -45,7 +45,7 @@
                     {% if level.teacher_markdown %}
                     <div id="level-expando-{{ lesson.number }}-{{ level.position }}" class="level-panel" data-level="{{ level.position }}" markdown="1">
 
-                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link fa">
+                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
                             View on Code Studio
                         </a>
 
@@ -59,7 +59,7 @@
                     <!-- Student Overview Content -->
                     <div id="level-expando-{{ lesson.number }}-{{ level.position }}-sfmd" class="level-panel" data-level="{{ level.position }}" markdown="1">
 
-                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link fa">
+                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
                             View on Code Studio
                         </a>
 
@@ -142,7 +142,7 @@
                     {% for level in chunk.levels %}
                     <div id="level-expando-{{ lesson.number }}-{{ level.position }}" class="level-panel" data-level="{{ level.position }}">
 
-                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link fa">
+                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
                             View on Code Studio
                         </a>
 

--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -45,7 +45,7 @@
                     {% if level.teacher_markdown %}
                     <div id="level-expando-{{ lesson.number }}-{{ level.position }}" class="level-panel" data-level="{{ level.position }}" markdown="1">
 
-                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
+                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link fa">
                             View on Code Studio
                         </a>
 
@@ -59,7 +59,7 @@
                     <!-- Student Overview Content -->
                     <div id="level-expando-{{ lesson.number }}-{{ level.position }}-sfmd" class="level-panel" data-level="{{ level.position }}" markdown="1">
 
-                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
+                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link fa">
                             View on Code Studio
                         </a>
 
@@ -142,14 +142,14 @@
                     {% for level in chunk.levels %}
                     <div id="level-expando-{{ lesson.number }}-{{ level.position }}" class="level-panel" data-level="{{ level.position }}">
 
-                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
+                        <a href="{{ level.path|level_link }}" target="_blank" class="level-link fa">
                             View on Code Studio
                         </a>
 
                         <!-- TODO: Remove outer if statement here when -->
                         <!-- we want to roll out for all courses not just CSD -->
                         {% if 'csd' in level.path and '2019' in level.path %}
-                            {% if level.mini_rubric %}
+                            {% if level.mini_rubric == "true" %}
                                 <div class="admonition assessment">
                                     <p class="admonition-title">
                                         <i class="fa fa-check-circle" aria-hidden="true"></i>

--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -752,6 +752,8 @@ th a:link, th a:visited, th a:hover, th a:active {
 }
 
 .level-link:after {
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: inherit;
     content: "\f08e";
 }
 

--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -752,8 +752,6 @@ th a:link, th a:visited, th a:hover, th a:active {
 }
 
 .level-link:after {
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: inherit;
     content: "\f08e";
 }
 
@@ -819,7 +817,9 @@ th a:link, th a:visited, th a:hover, th a:active {
 .type-FreeResponse .level-icon:before,
 .type-Multi .level-icon:before,
 .type-Match .level-icon:before,
-.type-Eval .level-icon:before{
+.type-Eval .level-icon:before,
+.type-LevelGroup .level-icon:before
+{
     content: "\f0ca";
 }
 


### PR DESCRIPTION
# Mini Rubric Shells Showing Up On Non-Mini Rubric Levels

## Before
<img width="1006" alt="Screen Shot 2019-04-01 at 12 16 04 PM" src="https://user-images.githubusercontent.com/208083/55342944-fcc32680-5477-11e9-9fe5-42bbc026e071.png">

## After
<img width="921" alt="Screen Shot 2019-04-01 at 12 13 41 PM" src="https://user-images.githubusercontent.com/208083/55342945-fcc32680-5477-11e9-93a9-8c0919fd677a.png">

# LevelGroup Icon Incorrect

## Before
<img width="1010" alt="Screen Shot 2019-04-01 at 12 11 58 PM" src="https://user-images.githubusercontent.com/208083/55342735-71e22c00-5477-11e9-8a71-c0fe0f8b5a3b.png">

## After
<img width="954" alt="Screen Shot 2019-04-01 at 12 11 41 PM" src="https://user-images.githubusercontent.com/208083/55342721-6abb1e00-5477-11e9-8783-84d48007a237.png">

