### PR TITLE
Lesson Front Page: Move assessment opportunities area to left column

### DIFF
--- a/curricula/templates/curricula/partials/lesson_front.html
+++ b/curricula/templates/curricula/partials/lesson_front.html
@@ -37,6 +37,17 @@
             {% endeditable %}
         {% endif %}
 
+        <!-- Assessment -->
+
+        {% if lesson.assessment %}
+            <h2>Assessment Opportunities</h2>
+            <div class="assessment">
+                {% editable lesson.assessment %}
+                    {{ lesson.assessment|richtext_filters|safe }}
+                {% endeditable %}
+            </div>
+        {% endif %}
+
         <h2>Agenda</h2>
         <div class="toc" id="toc{{ lesson|slugify }}">
             {% for activity in lesson.activity_set.all %}
@@ -79,17 +90,6 @@
                     <li>{% editable objective.name %}{{ objective.name }}{% endeditable %}</li>
                 {% endfor %}
             </ul>
-        {% endif %}
-
-<!-- Assessment -->
-
-        {% if lesson.assessment %}
-            <h2>Assessment Opportunity</h2>
-            <div class="assessment">
-                {% editable lesson.assessment %}
-                    {{ lesson.assessment|richtext_filters|safe }}
-                {% endeditable %}
-            </div>
         {% endif %}
 
 <!-- Prep -->


### PR DESCRIPTION
Assessment Opportunities Area was getting too long for the right column so Curriculum asked that it be moved to the left column.

## Before

<img width="913" alt="Screen Shot 2019-04-01 at 2 24 24 PM" src="https://user-images.githubusercontent.com/208083/55350403-05bcf380-548a-11e9-90a4-b626ca8ff8ca.png">

## After
<img width="940" alt="Screen Shot 2019-04-01 at 2 24 58 PM" src="https://user-images.githubusercontent.com/208083/55350404-05bcf380-548a-11e9-91a3-b61c79502781.png">
