### PR TITLE
Add parsed_long_instructions level attribute if long_instructions con…

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -203,7 +203,11 @@
                             <h3>Student Instructions</h3>
                             {{ level.markdown|richtext_filters|safe }}
                             {{ level.markdown_instructions|richtext_filters|safe }}
-                            {{ level.long_instructions|richtext_filters|safe }}
+                            {% if level.parsed_long_instructions %}
+                                {{ level.parsed_long_instructions|richtext_filters|safe }}
+                            {% else %}
+                                {{ level.long_instructions|richtext_filters|safe }}
+                            {% endif %}
                         </div>
 
                         <!-- Embed video if present -->

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -396,6 +396,20 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
                     counter += 1
                     levels.insert(counter, {'named': last_type, 'progression': last_progression, 'levels': []})
 
+                # Use value of block-text attribute in long_instructions to build parsed_long_instructions,
+                # which replaces <xml></xml> with block-text, if present.
+                long_instructions = level.get('long_instructions')
+                if long_instructions:
+                    # Use single- or double-quotes as the delimiter for our block-text attribute.
+                    # Note: This means the value of block-text cannot have single- or double-quotes
+                    # in it.
+                    match = re.search(r"block-text=[\"\'](?P<block_text>[^\"\']+)[\"\']", long_instructions)
+                    if match and match.group('block_text'):
+                        block_text = match.group('block_text')
+                        parsed_long_instructions = re.sub(r"(<xml>.+</xml>)", block_text, long_instructions, 0, re.DOTALL)
+                        if parsed_long_instructions != long_instructions:
+                            level['parsed_long_instructions'] = parsed_long_instructions
+
                 levels[counter]['levels'].append(level)
 
             return levels


### PR DESCRIPTION
…tains XML

In `lesson.get_levels()`, add a `level.parsed_long_instructions` attribute for levels whose `long_instructions` contain a `block-text` attribute.

### Example
`/csf-19/coursee/6/` has the following value for its `long_instructions`:
```
Our fish tank needs some water!

Use the <xml><block type="gamelab_setBackground" inline="true" block-text="set background color">
    <value name="COLOR">
      <block type="colour_picker">
        <title name="COLOUR">#0000ff</title>
      </block>
    </value>
  </block></xml> block to make the background blue.
```

#### Before
![Screen Shot 2019-04-01 at 2 09 11 PM](https://user-images.githubusercontent.com/9812299/55359864-c1305880-5487-11e9-94bd-5b080ca36c2c.png)

#### After
![Screen Shot 2019-04-01 at 2 08 50 PM](https://user-images.githubusercontent.com/9812299/55359865-c1305880-5487-11e9-82a7-ea276ce2a237.png)
