### PR TITLE
Font Awesome Version 4.6.3 and View on Code Studio Icon

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -47,6 +47,7 @@
 
                         <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
                             View on Code Studio
+                            <span class="level-link-icon fa"></span>
                         </a>
 
                         <div class="teacher-markdown">
@@ -61,6 +62,7 @@
 
                         <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
                             View on Code Studio
+                            <span class="level-link-icon fa"></span>
                         </a>
 
                         <div class="instructions-markdown">
@@ -144,6 +146,7 @@
 
                         <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
                             View on Code Studio
+                            <span class="level-link-icon fa"></span>
                         </a>
 
                         <!-- TODO: Remove outer if statement here when -->

--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -746,7 +746,7 @@ th a:link, th a:visited, th a:hover, th a:active {
 }
 
 .level-link-icon:before {
-    content: "\f35d";
+    content: "\f08e";
 }
 
 /*

--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -746,7 +746,7 @@ th a:link, th a:visited, th a:hover, th a:active {
 }
 
 .level-link-icon:before {
-    content: "\f0a9";
+    content: "\f35d";
 }
 
 /*

--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -741,20 +741,12 @@ th a:link, th a:visited, th a:hover, th a:active {
 */
 
 .level-link {
-    /*
-    margin: 5px 10px 5px 0;
-    padding: 5px;
-    border: 2px solid #cfc9de;
-    border-radius: 5px;
-    */
     font-size: .75em;
     float: right;
 }
 
-.level-link:after {
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: inherit;
-    content: "\f08e";
+.level-link-icon:before {
+    content: "\f0a9";
 }
 
 /*

--- a/templates/basecurriculum.html
+++ b/templates/basecurriculum.html
@@ -17,8 +17,7 @@
     <title>{% block meta_title %}Code.org CurriculumBuilder{% endblock %}</title>
     <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
     <link rel="stylesheet" href="{% static "css/bootstrap.min.css" %}">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/v4-shims.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
     <link rel="stylesheet" href="{% static "css/jquery-ui.min.css" %}">
 
     {% compress css %}

--- a/templates/cdo_base.html
+++ b/templates/cdo_base.html
@@ -10,8 +10,7 @@
     <title>{% block meta_title %}Code.org Tool Documentation{% endblock %}</title>
     <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
     <link rel="stylesheet" href="{% static "css/bootstrap.min.css" %}">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/v4-shims.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
     <link rel="stylesheet" href="{% static "css/jquery-ui.min.css" %}">
 
     {% compress css %}


### PR DESCRIPTION
# Font Awesome Version
Rolls us back to Font Awesome Version 4.6.3 to match Code Studio. (Reverses the work of this commit: https://github.com/mrjoshida/curriculumbuilder/commit/7023033ac29a5950a0e0ff1fc1ff9c9baa0129a8)

# View on Code Studio Icon
By rolling back to the earlier version of Font Awesome we can use the external-link icon again. This also sets it up with the styling we needed to do so it would not show as a blank square.

<img width="143" alt="Screen Shot 2019-04-02 at 10 07 53 AM" src="https://user-images.githubusercontent.com/208083/55409156-78cc7580-552f-11e9-9a83-7fbc70b3c098.png">




