### PR TITLE
Refactor parsed_long_instructions to account for multiple XML blocks

### DIFF
--- a/lessons/models.py
+++ b/lessons/models.py
@@ -376,6 +376,20 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
     def get_curriculum(self):
         return self.get_unit().curriculum
 
+    def parse_xml_block_text(self, str):
+        def replace(matchobj):
+            # Use single- or double-quotes as the delimiter for our block-text attribute.
+            # Note: This means the value of block-text cannot have single- or double-quotes
+            # in it.
+            match = re.search(r"block-text=[\"\'](?P<block_text>[^\"\']+)[\"\']", matchobj.group(0))
+            if match and match.group('block_text'):
+                block_text = match.group('block_text')
+                return block_text
+            else:
+                return matchobj.group(0)
+
+        return re.sub(r"(<xml>.+?</xml>)", replace, str, 0, re.DOTALL)
+
     def get_levels(self):
         if self.stage:
             raw_levels = self.stage.get('levels')
@@ -400,15 +414,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
                 # which replaces <xml></xml> with block-text, if present.
                 long_instructions = level.get('long_instructions')
                 if long_instructions:
-                    # Use single- or double-quotes as the delimiter for our block-text attribute.
-                    # Note: This means the value of block-text cannot have single- or double-quotes
-                    # in it.
-                    match = re.search(r"block-text=[\"\'](?P<block_text>[^\"\']+)[\"\']", long_instructions)
-                    if match and match.group('block_text'):
-                        block_text = match.group('block_text')
-                        parsed_long_instructions = re.sub(r"(<xml>.+</xml>)", block_text, long_instructions, 0, re.DOTALL)
-                        if parsed_long_instructions != long_instructions:
-                            level['parsed_long_instructions'] = parsed_long_instructions
+                    level['parsed_long_instructions'] = self.parse_xml_block_text(long_instructions)
 
                 levels[counter]['levels'].append(level)
 


### PR DESCRIPTION
Follow-up for #98, which did not account for levels that have multiple XML blocks in their long_instructions.

### Example
This level has 2 blockly XML blocks:
![instructions](https://user-images.githubusercontent.com/9812299/55439439-754de400-5559-11e9-9585-c349eceb705d.png)

### Before
"blocks to the bottom of the" (text between the two XML blocks) is missing:
![Screen Shot 2019-04-02 at 3 09 23 PM](https://user-images.githubusercontent.com/9812299/55439399-52bbcb00-5559-11e9-9062-ae0c6bb4ed8c.png)

### After
"blocks to the bottom of the" (text between the two XML blocks) is present:
![Screen Shot 2019-04-02 at 3 08 31 PM](https://user-images.githubusercontent.com/9812299/55439358-315adf00-5559-11e9-971b-9eaeb04f8222.png)
