### PR TITLE
CSF Concept Groups

### DIFF
--- a/curricula/templates/curricula/csf_unit.html
+++ b/curricula/templates/curricula/csf_unit.html
@@ -1,4 +1,15 @@
 {% extends "curricula/unit.html" %}
+
+{% comment %}Hide chapter label in header{% endcomment %}
+<!-- Header Bubbles -->
+
+{% block lessonnumber %}
+    <div class="unitnumber">{{ unit.header_corner|safe }}</div>
+
+    {% include "curricula/partials/csf_bubbles_header.html" with unit=unit %}
+
+{% endblock %}
+
 {% block chapter_title %}
     <div class="chapter concept-group">
     <h1>{{ chapter.title }}</h1>

--- a/curricula/templates/curricula/csf_unit.html
+++ b/curricula/templates/curricula/csf_unit.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block chapter_title %}
-    <div class="chapter concept-group">
+    <div class="chapter concept_group">
     <h1>{{ chapter.title }}</h1>
 {% endblock %}
 

--- a/curricula/templates/curricula/csf_unit.html
+++ b/curricula/templates/curricula/csf_unit.html
@@ -3,3 +3,6 @@
     <div class="chapter concept-group">
     <h1>{{ chapter.title }}</h1>
 {% endblock %}
+
+{% comment %}Hide chapter commentary{% endcomment %}
+{% block chapter_commentary %}{% endblock %}

--- a/curricula/templates/curricula/csf_unit.html
+++ b/curricula/templates/curricula/csf_unit.html
@@ -1,0 +1,5 @@
+{% extends "curricula/unit.html" %}
+{% block chapter_title %}
+    <div class="chapter concept-group">
+    <h1>{{ chapter.title }}</h1>
+{% endblock %}

--- a/curricula/templates/curricula/partials/bubbles_header.html
+++ b/curricula/templates/curricula/partials/bubbles_header.html
@@ -1,9 +1,11 @@
 <div class="lessons">
     {% if unit.chapters %}
         {% for chap in unit.chapters %}
+            {% block bubble_chapter_label %}
             <div class="lesson chapter">
                 Ch. {{ chap.number }}
             </div>
+            {% endblock %}
             {% for stage in chap.lessons %}
                 {% if stage.number < lesson.number %}
                     <div class="lesson finished">

--- a/curricula/templates/curricula/partials/csf_bubbles_header.html
+++ b/curricula/templates/curricula/partials/csf_bubbles_header.html
@@ -1,0 +1,2 @@
+{% extends "curricula/partials/bubbles_header.html" %}
+{% block bubble_chapter_label %}{% endblock %}

--- a/curricula/templates/curricula/unit.html
+++ b/curricula/templates/curricula/unit.html
@@ -182,7 +182,7 @@
                     {% endfor %}
                 {% endfor %}
                 </div>
-
+                {% block chapter_commentary %}
                 <details>
                     <summary>Chapter Commentary</summary>
 
@@ -190,6 +190,7 @@
                     {{ chapter.content|richtext_filters|safe }}
                     {% endeditable %}
                 </details>
+                {% endblock %}
                 {% if not forloop.last %}<hr/>{% endif %}
             {% endfor %}
         {% else %}

--- a/curricula/templates/curricula/unit.html
+++ b/curricula/templates/curricula/unit.html
@@ -84,8 +84,10 @@
         {% if unit.chapters %}
             {% for chapter in unit.chapters %}
 
+                {% block chapter_title %}
                 <div class="chapter">
                 <h1>Chapter {{ chapter.number }}: {{ chapter.title }}</h1>
+                {% endblock %}
 
                 {% if chapter.questions %}
                     <div class="big_questions">

--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -581,6 +581,12 @@ th a:link, th a:visited, th a:hover, th a:active {
     border: none;
 }
 
+.chapter_overviews .concept_group {
+    border: 3px solid rgb(207, 201, 222);
+    padding: 20px;
+    border-radius: 4px;
+}
+
 .lesson_overview {
     display: inline-block;
     clear:both;


### PR DESCRIPTION
CSF is restructuring for 19-20 around concept groups (sequences of lessons that build towards application of a concept). This is structurally similar to the chapters we use in CSD and CSP, but the current chapter language and styling doesn't fit. This introduces unit and lesson override templates to restyle 19-20 CSF lessons only. In order to see these changes a course must be
* (re)structured to use chapters
* apply the "curriculum/csf_unit.html" override template at the curriculum level
* apply the "curriculum/csf_lesson.html" override template at the unit level