### PR TITLE
Add gettext to the heroku dynos

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,4 @@
 python-cairo
 https://artifacts.crowdin.com/repo/deb/crowdin.deb
 default-jre
+gettext


### PR DESCRIPTION
Used by the Django translation system, added in
https://github.com/mrjoshida/curriculumbuilder/pull/74