### PR TITLE
Enable gettext as a buildpack, rather than from apt

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,4 +1,3 @@
 python-cairo
 https://artifacts.crowdin.com/repo/deb/crowdin.deb
 default-jre
-gettext

--- a/app.json
+++ b/app.json
@@ -106,6 +106,9 @@
     },
     {
       "url": "heroku/python"
+    },
+    {
+      "url": "https://github.com/piotras/heroku-buildpack-gettext"
     }
   ]
 }


### PR DESCRIPTION
Followup to https://github.com/mrjoshida/curriculumbuilder/pull/109