### PR TITLE
use locale_name for sync out

### DIFF
--- a/i18n/config/crowdin.yml
+++ b/i18n/config/crowdin.yml
@@ -36,15 +36,5 @@ files: [
   # e.g. "update_as_unapproved" or "update_without_changes"
   #
   "update_option" : "update_without_changes",
-
-  # Crowdin shortens languages without locale variation to just two characters,
-  # but we always want to use four
-  "languages_mapping": {
-    "locale_with_underscore": {
-      "it": "it_IT",
-      "th": "th_TH",
-      "sk": "sk_SK",
-    }
-  }
  },
 ]

--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -6,13 +6,12 @@ import subprocess
 from django.core import management
 from django.core.management.base import BaseCommand
 
-from i18n.management.utils import log, get_non_english_language_codes, get_models_to_sync
+from i18n.management.utils import log, get_non_english_locale_names, get_models_to_sync
 from i18n.utils import I18nFileWrapper
 
 
 class Command(BaseCommand):
     source_dir = os.path.join(I18nFileWrapper.static_dir(), 'source')
-    translations_dir = os.path.join(I18nFileWrapper.static_dir(), 'translations')
 
     def download_translations(self):
         """Download translations from crowdin"""
@@ -32,12 +31,15 @@ class Command(BaseCommand):
         ]
         log("Restoring redacted translations for %s" %
             ', '.join(model.__name__ for model in models_to_restore))
-        log("For %s" % ", ".join(get_non_english_language_codes()))
-        for locale in get_non_english_language_codes():
+        log("For %s" % ", ".join(get_non_english_locale_names()))
+        for locale_name in get_non_english_locale_names():
             for model in models_to_restore:
                 filename = model.__name__ + ".json"
                 source_path = os.path.join(self.source_dir, filename)
-                translation_path = os.path.join(self.translations_dir, locale, filename)
+                translation_path = os.path.join(
+                    I18nFileWrapper.locale_dir_absolute(locale_name),
+                    filename
+                )
                 if not os.path.exists(translation_path):
                     log("Could not find %s to restore" % translation_path)
                     continue
@@ -50,7 +52,6 @@ class Command(BaseCommand):
                     '-o', translation_path,
                     '-p', plugins
                 ])
-            print_clear("%s - finished" % locale, end='\n')
 
         # Compile Django translations
         management.call_command("compilemessages")
@@ -60,14 +61,15 @@ class Command(BaseCommand):
         source_paths = glob.glob(os.path.join(self.source_dir, '*'))
         log("Uploading restored translations to S3: %s" %
             ", ".join(map(os.path.basename, source_paths)))
-        for locale in get_non_english_language_codes():
-            for translation_path in glob.glob(os.path.join(self.translations_dir, locale, '*')):
+        for locale_name in get_non_english_locale_names():
+            translations_glob = os.path.join(I18nFileWrapper.locale_dir_absolute(locale_name), '*')
+            for translation_path in glob.glob(translations_glob):
                 if not os.path.exists(translation_path):
                     log("Could not find %s to upload" % translation_path)
                     continue
                 filename = os.path.basename(translation_path)
                 with open(translation_path) as translation_file:
-                    dest_path = os.path.join('translations', locale, filename)
+                    dest_path = os.path.join(I18nFileWrapper.locale_dir(locale_name), filename)
                     I18nFileWrapper.storage().save(dest_path, translation_file)
 
     def handle(self, *args, **options):

--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -4,6 +4,8 @@ Helper methods for use during the i18n sync process
 import django.apps
 
 from django.conf import settings
+from django.utils.translation import to_locale
+
 from django_slack import slack_message
 
 from i18n.models import Internationalizable
@@ -26,12 +28,22 @@ def get_models_to_sync():
 
 def get_non_english_language_codes():
     """
-    Retrieve all languages codes (ie "es-mx") for languages we need to process
+    Retrieve all language codes (ie "es-mx") for languages we need to process
     in the i18n sync.
     """
     return [
-        locale for locale, _ in settings.LANGUAGES
-        if not locale == settings.LANGUAGE_CODE
+        language_code for language_code, _ in settings.LANGUAGES
+        if not language_code == settings.LANGUAGE_CODE
+    ]
+
+def get_non_english_locale_names():
+    """
+    Retrieve all locale names (ie "es_MX") for languages we need to process
+    in the i18n sync.
+    """
+    return [
+        to_locale(language_code) for language_code
+        in get_non_english_language_codes()
     ]
 
 def log(message):

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -30,10 +30,26 @@ class I18nFileWrapper:
         return os.path.join(cls.i18n_dir(), 'static')
 
     @classmethod
+    def locale_dir(cls, locale_name):
+        """
+        Return the relative directory in which we expect translations to be
+        stored for the given locale name
+        """
+        return os.path.join("translations", locale_name, "LC_MESSAGES")
+
+    @classmethod
+    def locale_dir_absolute(cls, locale_name):
+        """
+        Return the absolute directory in which we expect translations to be
+        stored for the given locale name
+        """
+        return os.path.join(cls.static_dir(), "translations", locale_name, "LC_MESSAGES")
+
+    @classmethod
     def _load_translations(cls, name, lang):
         # Construct the path for translations. Django requires some translations
         # to exist in a LC_MESSAGES directory, so let's put them all there.
-        path = os.path.join("translations", lang, "LC_MESSAGES", name + ".json")
+        path = os.path.join(cls.locale_dir(lang), name + ".json")
         translations = cache.get(path)
         if translations is None:
             try:


### PR DESCRIPTION
In https://github.com/mrjoshida/curriculumbuilder/pull/74, we updated the locations of the translations files for the sync in and down, but needed to also update the other parts of the sync out (ie, restoration and uploading).

In part, that was because we were manually specifying the location of the i18n files in several locations; I've updated all these to use the new I18nFileWrapper.locale_dir method, which should mean that future changes of this nature only have to happen in one place.

I also removed the `languages_mapping` in the crowdin config, since it appears that the `locale_with_underscore` settings means that crowdin does, in fact, use the four-character version