### PR TITLE
Fix capitalization of in-context-translation pseudo-language

### DIFF
--- a/i18n/config/crowdin.yml
+++ b/i18n/config/crowdin.yml
@@ -37,4 +37,13 @@ files: [
   #
   "update_option" : "update_without_changes",
  },
+
+ # For some reason, Crowdin lowercases locale_with_underscore for the
+ # pseudo-language we use for in-context translation (and only that language),
+ # so we coerce it here to xx_YY format like all the other languages.
+  "languages_mapping": {
+    "locale_with_underscore": {
+      "in_tl": "in_TL",
+    }
+  }
 ]


### PR DESCRIPTION
For some reason, when downloading translations using
locale_with_underscore, crowdin correctly uppercases the locale for all
languages EXCEPT the pseudo-language we use to enable in-context
translations. So we have to manually coerce it to the right format.