### PR TITLE
Mini Rubric: Performance Level Naming Clean Up

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -163,25 +163,25 @@
                                         <details class="rubric-performance-level">
                                             <summary>Extensive Evidence</summary>
                                             <p>
-                                                {{ level.rubric_exceeds|richtext_filters|safe }}
+                                                {{ level.rubric_performance_level_1|richtext_filters|safe }}
                                             </p>
                                         </details>
                                         <details class="rubric-performance-level">
                                             <summary>Convincing Evidence</summary>
                                             <p>
-                                                {{ level.rubric_meets|richtext_filters|safe }}
+                                                {{ level.rubric_performance_level_2|richtext_filters|safe }}
                                             </p>
                                         </details>
                                         <details class="rubric-performance-level">
                                             <summary>Limited Evidence</summary>
                                             <p>
-                                                {{ level.rubric_approaches|richtext_filters|safe }}
+                                                {{ level.rubric_performance_level_3|richtext_filters|safe }}
                                             </p>
                                         </details>
                                         <details class="rubric-performance-level">
                                             <summary>No Evidence</summary>
                                             <p>
-                                                {{ level.rubric_no_evidence|richtext_filters|safe }}
+                                                {{ level.rubric_performance_level_4|richtext_filters|safe }}
                                             </p>
                                         </details>
                                     </div>


### PR DESCRIPTION
Update the level pull through to pull through using the new way we are saving performance level values.

# Before
<img width="508" alt="Screen Shot 2019-04-23 at 1 34 46 PM" src="https://user-images.githubusercontent.com/208083/56602947-9a6bca80-65cc-11e9-8d68-b49ae9447ee1.png">

# After
<img width="457" alt="Screen Shot 2019-04-23 at 1 32 21 PM" src="https://user-images.githubusercontent.com/208083/56602911-8627cd80-65cc-11e9-9d9e-33e098a3b16c.png">
ore