### PR TITLE
Show assessment icon in the correct place for named assessment levels

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -14,18 +14,19 @@
                     <!-- Header tabs -->
                     <ul>
                         <li class="chunk-header type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
-                            {{ level.display_name|default:level.name }} <span class="level-icon fa"></span>
-                        </li>
-                        {% if level.teacher_markdown %}
-                        <li class="level-bubble type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
-                            <a href="#level-expando-{{ lesson.number }}-{{ level.position }}">
-                                <!-- TODO: Remove outer if statement here when -->
+                            {{ level.display_name|default:level.name }}
+                            <span class="level-icon fa"></span>
+                            <!-- TODO: Remove outer if statement here when -->
                                     <!-- we want to roll out for all courses -->
                                     {% if '2019' in level.path %}
                                         {% if level.assessment %}
                                             <i class=" fa-check-circle fa"></i>
                                         {% endif %}
                                     {% endif %}
+                        </li>
+                        {% if level.teacher_markdown %}
+                        <li class="level-bubble type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
+                            <a href="#level-expando-{{ lesson.number }}-{{ level.position }}">
                                 Teacher Overview
                             </a>
                         </li>


### PR DESCRIPTION
Now that a named level can also be an assessment level we need to indicate that correctly in the code studio pull through.  Below is what it ends up looking like.

<img width="930" alt="Screen Shot 2019-04-24 at 4 26 44 PM" src="https://user-images.githubusercontent.com/208083/56691498-17bb3c00-66ae-11e9-966c-8921f241cdca.png">
