### PR TITLE
Keywords i18n serializer

### DIFF
--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -42,11 +42,12 @@ class LessonSerializer(serializers.ModelSerializer):
     student_resources = serializers.SerializerMethodField()
     vocab = serializers.SerializerMethodField()
     blocks = serializers.SerializerMethodField()
+    keywords = serializers.SerializerMethodField()
 
     class Meta:
         model = Lesson
         fields = ('title', 'number', 'student_desc', 'teacher_desc',
-                  'student_resources', 'teacher_resources', 'vocab', 'blocks')
+                  'student_resources', 'teacher_resources', 'vocab', 'blocks', 'keywords')
 
     def get_teacher_desc(self, obj):
         return obj.overview
@@ -73,6 +74,9 @@ class LessonSerializer(serializers.ModelSerializer):
         blocks = obj.blocks.all()
         serializer = BlockSerializer(blocks, many=True)
         return serializer.data
+
+    def get_keywords(self, obj):
+        return [str(k) for k in obj.keywords.all()]
 
 
 class UnitSerializer(serializers.ModelSerializer):

--- a/i18n/models.py
+++ b/i18n/models.py
@@ -47,6 +47,7 @@ class Internationalizable(models.Model):
 
     @classmethod
     def get_serializer(cls):
+        # Dynamic loading with https://stackoverflow.com/questions/547829/how-to-dynamically-load-a-python-class
         name = cls.__name__ + 'Serializer'
         serializers = __import__('curricula.serializers', fromlist=[name])
         return getattr(serializers, name, None)

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -304,7 +304,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
 
     @classmethod
     def internationalizable_fields(cls):
-        return super(Lesson, cls).internationalizable_fields() + ['overview', 'short_title', 'cs_content', 'prep']
+        return super(Lesson, cls).internationalizable_fields() + ['overview', 'short_title', 'cs_content', 'prep', 'keywords']
 
     def __unicode__(self):
         return self.title


### PR DESCRIPTION
Allow iterable fields to be added to `internationalizable_fields` (provided a matching serializer). Sample source/Lesson.json:

```js
"coursee/introduction-course-warm-up": {
    "cs_content": "We recognize that every classroom has a spectrum of understanding for every subject. Some students in your class may be computer wizards, while others haven't had much experience at all. In order to create an equal playing (and learning) field, we have developed this \"Ramp-Up Stage\" for Course E. This can be used as either an introduction or a review to the Code.org interface and basic computer science concepts. This stage, along with the three that follow, cover all prerequisites needed to start Course E.", 
    "description": "This lesson will give you practice in the skills you will need for this course.", 
    "keywords": [
        "Sequencing", 
        "Debugging", 
        "Loop", 
        "Ice Age", 
        "Maze", 
        "Artist"
    ], 
    "overview": "In this progression, students will begin with an introduction (or review depending on the experience of your class) of Code.org's online workspace. Students will learn the basic functionality of the interface including the `Run`, `Reset`, and `Step` buttons. Dragging, deleting, and connecting Blockly blocks is also introduced in the beginning video. In the puzzles, students will practice their sequencing and debugging skills in Maze and Artist.", 
    "prep": " - Play through puzzles on [r csf-course-e] to find any potential problem areas for your class.\r\n - Make sure every student has a [r think-spot-journal].", 
    "title": "Introduction to Online Puzzles"
}, 
```

https://codedotorg.atlassian.net/browse/FND-232