### PR TITLE
Make `Vocab` a translatable model

### DIFF
--- a/lessons/migrations/0043_auto_20190520_1630.py
+++ b/lessons/migrations/0043_auto_20190520_1630.py
@@ -11,9 +11,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name='vocab',
-            name='word',
-            field=models.CharField(unique=True, max_length=255),
+        migrations.AlterUniqueTogether(
+            name='vocab',
+            unique_together=('word', 'mathy'),
         ),
     ]

--- a/lessons/migrations/0043_auto_20190520_1630.py
+++ b/lessons/migrations/0043_auto_20190520_1630.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lessons', '0042_lesson_assessment'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='vocab',
+            name='word',
+            field=models.CharField(unique=True, max_length=255),
+        ),
+    ]

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -53,7 +53,7 @@ Vocabulary
 
 
 class Vocab(Internationalizable):
-    word = models.CharField(unique=True, max_length=255)
+    word = models.CharField(max_length=255)
     simpleDef = models.TextField()
     detailDef = models.TextField(blank=True, null=True)
     mathy = models.BooleanField(default=False)
@@ -61,6 +61,7 @@ class Vocab(Internationalizable):
     class Meta:
         ordering = ["word"]
         verbose_name_plural = "vocab words"
+        unique_together = ('word', 'mathy')
 
     @property
     def i18n_key(self):

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -53,7 +53,7 @@ Vocabulary
 
 
 class Vocab(Internationalizable):
-    word = models.CharField(max_length=255)
+    word = models.CharField(unique=True, max_length=255)
     simpleDef = models.TextField()
     detailDef = models.TextField(blank=True, null=True)
     mathy = models.BooleanField(default=False)

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -70,10 +70,6 @@ class Vocab(Internationalizable):
     def internationalizable_fields(cls):
         return ['word', 'simpleDef', 'detailDef']
 
-    @classmethod
-    def get_i18n_objects(cls):
-        return super(Vocab, cls).get_i18n_objects()
-
     @property
     def should_be_translated(self):
         return any(lesson.should_be_translated for lesson in self.lesson_set.all())

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -64,7 +64,7 @@ class Vocab(Internationalizable):
 
     @property
     def i18n_key(self):
-        return self.word
+        return slugify(self.get_untranslated_field('word'))
 
     @classmethod
     def internationalizable_fields(cls):

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -72,7 +72,7 @@ class Vocab(Internationalizable):
 
     @property
     def should_be_translated(self):
-        return any(lesson.should_be_translated for lesson in self.lesson_set.all()) and not self.mathy
+        return not self.mathy and any(lesson.should_be_translated for lesson in self.lesson_set.all())
 
     def __unicode__(self):
         if self.mathy:

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -52,7 +52,7 @@ Vocabulary
 """
 
 
-class Vocab(models.Model):
+class Vocab(Internationalizable):
     word = models.CharField(max_length=255)
     simpleDef = models.TextField()
     detailDef = models.TextField(blank=True, null=True)
@@ -61,6 +61,22 @@ class Vocab(models.Model):
     class Meta:
         ordering = ["word"]
         verbose_name_plural = "vocab words"
+
+    @property
+    def i18n_key(self):
+        return self.word
+
+    @classmethod
+    def internationalizable_fields(cls):
+        return ['word', 'simpleDef', 'detailDef']
+
+    @classmethod
+    def get_i18n_objects(cls):
+        return super(Vocab, cls).get_i18n_objects()
+
+    @property
+    def should_be_translated(self):
+        return any(lesson.should_be_translated for lesson in self.lesson_set.all())
 
     def __unicode__(self):
         if self.mathy:

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -72,7 +72,7 @@ class Vocab(Internationalizable):
 
     @property
     def should_be_translated(self):
-        return any(lesson.should_be_translated for lesson in self.lesson_set.all())
+        return any(lesson.should_be_translated for lesson in self.lesson_set.all()) and not self.mathy
 
     def __unicode__(self):
         if self.mathy:


### PR DESCRIPTION
Sample from source/Vocab.json:

```js
"command": {
    "detailDef": "An instruction for the computer. Many commands put together make up algorithms and computer programs. ", 
    "simpleDef": "An instruction for the computer. Many commands put together make up algorithms and computer programs. ", 
    "word": "Command"
}, 
"condition": {
    "detailDef": "A statement that a program checks to see if it is true or false.  If true, an action is taken. Otherwise, the action is ignored.", 
    "simpleDef": "Something a program checks to see if it is true before allowing an action.", 
    "word": "Condition"
}, 
"conditionals": {
    "detailDef": "Statements that only run under certain conditions.", 
    "simpleDef": "Statements that only run under certain conditions.", 
    "word": "Conditionals"
}, 
```

Most of the short/long definitions are the same, but not all.