### PR TITLE
Assessment and Mini Rubric: Release to All Courses

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -16,13 +16,9 @@
                         <li class="chunk-header type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
                             {{ level.display_name|default:level.name }}
                             <span class="level-icon fa"></span>
-                            <!-- TODO: Remove outer if statement here when -->
-                                    <!-- we want to roll out for all courses -->
-                                    {% if '2019' in level.path %}
-                                        {% if level.assessment %}
-                                            <i class=" fa-check-circle fa"></i>
-                                        {% endif %}
-                                    {% endif %}
+                                {% if level.assessment %}
+                                    <i class=" fa-check-circle fa"></i>
+                                {% endif %}
                         </li>
                         {% if level.teacher_markdown %}
                         <li class="level-bubble type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
@@ -116,12 +112,8 @@
                         {% for level in chunk.levels %}
                             <li class="level-bubble type-{{ level.type }} {{ unit.slug }}-stage-{{ lesson.number }}-level-{{ level.position }}-tab" data-level="{{ level.position }}" data-named="{{ level.named_level }}">
                                 <a href="#level-expando-{{ lesson.number }}-{{ level.position }}">
-                                    <!-- TODO: Remove outer if statement here when -->
-                                    <!-- we want to roll out for all courses -->
-                                    {% if '2019' in level.path %}
-                                        {% if level.assessment %}
-                                            <i class="fa-check-circle fa"></i>
-                                        {% endif %}
+                                    {% if level.assessment %}
+                                        <i class="fa-check-circle fa"></i>
                                     {% endif %}
                                     <span class="level-icon fa"></span>
                                     {% if level.bonus_level %}
@@ -143,51 +135,46 @@
                             View on Code Studio
                             <span class="level-link-icon fa"></span>
                         </a>
-
-                        <!-- TODO: Remove outer if statement here when -->
-                        <!-- we want to roll out for all courses not just CSD -->
-                        {% if 'csd' in level.path and '2019' in level.path %}
-                            {% if level.mini_rubric == "true" %}
-                                <div class="admonition assessment">
-                                    <p class="admonition-title">
-                                        <i class="fa fa-check-circle" aria-hidden="true"></i>
-                                        Assessment Opportunities
+                        {% if level.mini_rubric == "true" %}
+                            <div class="admonition assessment">
+                                <p class="admonition-title">
+                                    <i class="fa fa-check-circle" aria-hidden="true"></i>
+                                    Assessment Opportunities
+                                </p>
+                                <div class="rubric-key-concept">
+                                    <span class="rubric-header">Key Concepts:</span>
+                                    <p>
+                                        {{ level.rubric_key_concept|richtext_filters|safe }}
                                     </p>
-                                    <div class="rubric-key-concept">
-                                        <span class="rubric-header">Key Concepts:</span>
-                                        <p>
-                                            {{ level.rubric_key_concept|richtext_filters|safe }}
-                                        </p>
-                                    </div>
-                                    <div>
-                                        <span class="rubric-header">Assessment Criteria:</span>
-                                        <details class="rubric-performance-level">
-                                            <summary>Extensive Evidence</summary>
-                                            <p>
-                                                {{ level.rubric_performance_level_1|richtext_filters|safe }}
-                                            </p>
-                                        </details>
-                                        <details class="rubric-performance-level">
-                                            <summary>Convincing Evidence</summary>
-                                            <p>
-                                                {{ level.rubric_performance_level_2|richtext_filters|safe }}
-                                            </p>
-                                        </details>
-                                        <details class="rubric-performance-level">
-                                            <summary>Limited Evidence</summary>
-                                            <p>
-                                                {{ level.rubric_performance_level_3|richtext_filters|safe }}
-                                            </p>
-                                        </details>
-                                        <details class="rubric-performance-level">
-                                            <summary>No Evidence</summary>
-                                            <p>
-                                                {{ level.rubric_performance_level_4|richtext_filters|safe }}
-                                            </p>
-                                        </details>
-                                    </div>
                                 </div>
-                            {% endif %}
+                                <div>
+                                    <span class="rubric-header">Assessment Criteria:</span>
+                                    <details class="rubric-performance-level">
+                                        <summary>Extensive Evidence</summary>
+                                        <p>
+                                            {{ level.rubric_performance_level_1|richtext_filters|safe }}
+                                        </p>
+                                    </details>
+                                    <details class="rubric-performance-level">
+                                        <summary>Convincing Evidence</summary>
+                                        <p>
+                                            {{ level.rubric_performance_level_2|richtext_filters|safe }}
+                                        </p>
+                                    </details>
+                                    <details class="rubric-performance-level">
+                                        <summary>Limited Evidence</summary>
+                                        <p>
+                                            {{ level.rubric_performance_level_3|richtext_filters|safe }}
+                                        </p>
+                                    </details>
+                                    <details class="rubric-performance-level">
+                                        <summary>No Evidence</summary>
+                                        <p>
+                                            {{ level.rubric_performance_level_4|richtext_filters|safe }}
+                                        </p>
+                                    </details>
+                                </div>
+                            </div>
                         {% endif %}
 
                         {% if level.teacher_markdown %}


### PR DESCRIPTION
Remove 2019 restriction on assessment design to match removing the flag on code studio.

This impacts the Code Studio Pull-Through. We will now show the assessment marker on any level marked as an assessment in any course. We will also show the mini rubric for any level that has a mini rubric.

<img width="1256" alt="Screen Shot 2019-05-20 at 12 18 49 PM" src="https://user-images.githubusercontent.com/208083/58036943-3fa98e00-7afa-11e9-9c85-6a04d601beef.png">
