### PR TITLE
Code Studio Pull Through: Contained Levels and Map Levels Fix

### DIFF
--- a/curricula/templates/curricula/partials/code_studio.html
+++ b/curricula/templates/curricula/partials/code_studio.html
@@ -75,13 +75,14 @@
                         </div>
                         {% endif %}
 
-                        <!-- Include contained levels for predictions -->
-                        {% if level.reference  and not pdf %}
+                        <!-- Curriculum Reference levels -->
+                        {% if level.reference and not pdf %}
                         <div class="curriculum-reference">
                             <iframe frameborder="0" class="map-embed" src="{{ level.reference|level_embed }}" width="100%" height="500"></iframe>
                         </div>
                         {% endif %}
 
+                        <!-- Include contained levels for predictions -->
                         {% if level.contained_levels %}
                             <div class="contained">
                                 {% for contained in level.contained_levels %}
@@ -91,7 +92,7 @@
                                         {{ contained.questions.0.text|richtext_filters|safe }}
                                     </div>
                                     {% for answer in contained.answers %}
-                                        <div class="answer answer-{{ answer.correct }}">{{ answer.text|richtext_filters|safe }}</div>
+                                        <div class="answer">{{ answer.text|richtext_filters|safe }}</div>
                                     {% endfor %}
                                 {% endfor %}
                             </div>
@@ -130,7 +131,6 @@
                     <!-- Body panels -->
                     {% for level in chunk.levels %}
                     <div id="level-expando-{{ lesson.number }}-{{ level.position }}" class="level-panel" data-level="{{ level.position }}">
-
                         <a href="{{ level.path|level_link }}" target="_blank" class="level-link">
                             View on Code Studio
                             <span class="level-link-icon fa"></span>
@@ -203,13 +203,24 @@
                         </div>
                         {% endif %}
 
-                        <!-- Include contained levels for predictions -->
-                        {% if level.reference and not pdf %}
-                        <div class="curriculum-reference">
-                            <iframe frameborder="0" class="map-embed" src="https://docs.code.org{{ level.reference }}" width="100%" height="500"></iframe>
+                        <!-- Curriculum Reference level -->
+                        {% if level.type == "LevelGroup" %}
+                        <div class="level-group">
+                            <p>
+                                This level is an assessment or survey with multiple questions.
+                                To view this level click the "View on Code Studio" link.
+                            </p>
                         </div>
                         {% endif %}
 
+                        <!-- Curriculum Reference level -->
+                        {% if level.reference and not pdf %}
+                        <div class="curriculum-reference">
+                            <iframe frameborder="0" class="map-embed" src="{{ level.reference|level_embed }}" width="100%" height="500"></iframe>
+                        </div>
+                        {% endif %}
+
+                        <!-- Include contained levels for predictions -->
                         {% if level.contained_levels %}
                             <div class="contained">
                                 {% for contained in level.contained_levels %}
@@ -219,7 +230,7 @@
                                         {{ contained.questions.0.text|richtext_filters|safe }}
                                     </div>
                                     {% for answer in contained.answers %}
-                                        <div class="answer answer-{{ answer.correct }}">{{ answer.text|richtext_filters|safe }}</div>
+                                        <div class="answer">{{ answer.text|richtext_filters|safe }}</div>
                                     {% endfor %}
                                 {% endfor %}
                             </div>


### PR DESCRIPTION
This fixes [LP-380](https://codedotorg.atlassian.net/browse/LP-380) and [LP-258](https://codedotorg.atlassian.net/browse/LP-258).

# LevelGroup Levels

Level group levels were not pulling through. Now we give a message that to view a level group you should head to Code Studio.

## Before

<img width="982" alt="Screen Shot 2019-05-30 at 11 17 41 AM" src="https://user-images.githubusercontent.com/208083/58643066-91a59d00-82cc-11e9-9793-cfccf60812c1.png">

## After
<img width="1020" alt="Screen Shot 2019-05-30 at 11 18 05 AM" src="https://user-images.githubusercontent.com/208083/58643087-9ff3b900-82cc-11e9-96e2-57d073f4d7b3.png">


# Contained Levels

Contained levels where marking answers as right or wrong which would give away the answer if a student were to find the lesson plans.  Instead we now just don't show which one is right or wrong!

## Before

<img width="1030" alt="Screen Shot 2019-03-29 at 2 23 16 PM" src="https://user-images.githubusercontent.com/208083/58642898-35427d80-82cc-11e9-849c-1b2d686c5014.png">

## After

<img width="1024" alt="Screen Shot 2019-05-30 at 11 15 01 AM" src="https://user-images.githubusercontent.com/208083/58642917-3a073180-82cc-11e9-967a-2a056fa66c19.png">

# Map Levels on Non-Named Levels

We just had a bug here where we were not doing the pull through for named levels and other levels the same. Updated the non-named levels to match the way we were using for named levels (which was working)

## Before

![image-2019-05-01-13-44-09-446](https://user-images.githubusercontent.com/208083/58643170-c580c280-82cc-11e9-9d7b-a5fc57eda2ec.png)

## After

<img width="1211" alt="Screen Shot 2019-05-30 at 11 19 09 AM" src="https://user-images.githubusercontent.com/208083/58643187-ca457680-82cc-11e9-82c1-aad9571107f7.png">


