### PR TITLE
Hide pdf links for lessons and handouts for csf-2019

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -296,6 +296,9 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
         return self.i18n_ready
 
     @property
+    def express_or_pre2019(self):
+        return (self.title == "Express" or self.title == "Pre Express") and self.curriculum.slug == 'csf-19'
+
     def has_resource_pdf(self):
         return self.curriculum.slug not in ['csf-19', 'csf-18', 'csf-1718', 'hoc']
 

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -297,7 +297,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
 
     @property
     def has_resource_pdf(self):
-        return self.curriculum.slug not in ['csf-18', 'csf-1718', 'hoc']
+        return self.curriculum.slug not in ['csf-19', 'csf-18', 'csf-1718', 'hoc']
 
     def can_move(self, request, new_parent):
         parent_type = getattr(new_parent, 'content_model', None)

--- a/curricula/templates/curricula/partials/lesson_pills.html
+++ b/curricula/templates/curricula/partials/lesson_pills.html
@@ -3,8 +3,8 @@
 <div class="resource-nav btn-toolbar" role="toolbar" aria-label="Lesson Resources">
     <div class="btn-group btn-group-xs" role="group" aria-label="PDF Buttons">
         <a href="{{ unit.get_absolute_url }}" class="btn" role="button">{% trans 'Unit Overview' %}</a>
-        {# Removing lessons PDF link from CSF until we can fix it #}
-        {% if unit.has_resource_pdf %}
+        {# Removing lessons PDF link from Express and Pre Express 2019 until we can fix it #}
+        {% if not unit.express_or_pre2019 %}
         <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'All Lessons PDF' %}</a>
         {% endif %}
         {# Removing handouts PDF link from CSF until we can fix it #}

--- a/curricula/templates/curricula/partials/lesson_pills.html
+++ b/curricula/templates/curricula/partials/lesson_pills.html
@@ -3,7 +3,10 @@
 <div class="resource-nav btn-toolbar" role="toolbar" aria-label="Lesson Resources">
     <div class="btn-group btn-group-xs" role="group" aria-label="PDF Buttons">
         <a href="{{ unit.get_absolute_url }}" class="btn" role="button">{% trans 'Unit Overview' %}</a>
+        {# Removing lessons PDF link from CSF until we can fix it #}
+        {% if unit.has_resource_pdf %}
         <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'All Lessons PDF' %}</a>
+        {% endif %}
         {# Removing handouts PDF link from CSF until we can fix it #}
         {% if unit.has_resource_pdf %}
         <a href="{{ unit.get_resources_pdf_url }}" class="btn" role="button">{% trans 'All Handouts PDF' %}</a>

--- a/curricula/templates/curricula/partials/unit_pills.html
+++ b/curricula/templates/curricula/partials/unit_pills.html
@@ -7,7 +7,10 @@
       {% if unit.vocab_count > 0 %}<a href="{{ unit.get_vocab_url }}" class="btn" role="button">{% trans 'Vocab' context 'Vocabulary' %}</a>{% endif %}
       {% if unit.block_count > 0 %}<a href="{{ unit.get_blocks_url }}" class="btn" role="button">{% trans 'Code Documentation' %}</a>{% endif %}
       <a href="{{ unit.get_resources_url }}" class="btn" role="button">{% trans 'Other Resources' %}</a>
-      <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'Lessons PDF' %}</a>
+        {# Removing lessons PDF link from CSF until we can fix it #}
+        {% if unit.has_resource_pdf %}
+        <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'Lessons PDF' %}</a>
+        {% endif %}
         {# Removing handouts PDF link from CSF until we can fix it #}
         {% if unit.has_resource_pdf %}
         <a href="{{ unit.get_resources_pdf_url }}" class="btn" role="button">{% trans 'Handouts PDF' %}</a>

--- a/curricula/templates/curricula/partials/unit_pills.html
+++ b/curricula/templates/curricula/partials/unit_pills.html
@@ -7,8 +7,8 @@
       {% if unit.vocab_count > 0 %}<a href="{{ unit.get_vocab_url }}" class="btn" role="button">{% trans 'Vocab' context 'Vocabulary' %}</a>{% endif %}
       {% if unit.block_count > 0 %}<a href="{{ unit.get_blocks_url }}" class="btn" role="button">{% trans 'Code Documentation' %}</a>{% endif %}
       <a href="{{ unit.get_resources_url }}" class="btn" role="button">{% trans 'Other Resources' %}</a>
-        {# Removing lessons PDF link from CSF until we can fix it #}
-        {% if unit.has_resource_pdf %}
+        {# Removing lessons PDF link from Express and Pre- Express 2019 until we can fix it #}
+        {% if not unit.express_or_pre2019 %}
         <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'Lessons PDF' %}</a>
         {% endif %}
         {# Removing handouts PDF link from CSF until we can fix it #}


### PR DESCRIPTION
Lesson plan and handout PDF links for CSF-19 currently dead end on a "Requested Page Not Found" page because there is a problem with PDF generation. 
<img width="1095" alt="Screen Shot 2019-06-20 at 5 23 21 PM" src="https://user-images.githubusercontent.com/12300669/59882420-29ecea00-9380-11e9-95bd-a49562004036.png">

The Learning Platform team is tracking a deeper investigation and longer term fix for PDF generation issues ([LP-545 ](https://codedotorg.atlassian.net/browse/LP-545)). 

In the meantime, I've removed the Lesson PDF and Handouts PDF links for Express & Pre Express 2019. 

BEFORE:
<img width="1108" alt="links-before" src="https://user-images.githubusercontent.com/12300669/59882595-9ff15100-9380-11e9-963e-82844a730197.png">

AFTER:
<img width="1115" alt="links-after" src="https://user-images.githubusercontent.com/12300669/59882601-a41d6e80-9380-11e9-8fa0-c4a9217603dc.png">
