### PR TITLE
Use strings for i18n keys

### DIFF
--- a/i18n/models.py
+++ b/i18n/models.py
@@ -77,7 +77,7 @@ class Internationalizable(models.Model):
 
     @property
     def i18n_key(self):
-        return self.pk
+        return str(self.pk)
 
     def get_untranslated_field(self, field):
         if field in self._untranslated_values:

--- a/i18n/tests/models.py
+++ b/i18n/tests/models.py
@@ -1,0 +1,13 @@
+from i18n.models import Internationalizable
+from django.db import models
+
+class TestModel(Internationalizable):
+    """
+    Minimal implementation of a Django model that supports internationalization
+    """
+    title = models.CharField(max_length=255)
+    description = models.TextField()
+
+    @classmethod
+    def internationalizable_fields(cls):
+        return ['title', 'description']

--- a/i18n/tests/test_internationalizable.py
+++ b/i18n/tests/test_internationalizable.py
@@ -1,21 +1,9 @@
 from unittest2 import TestCase
 
 from django.core.cache import cache
-from django.db import models
 from django.utils import translation
 
-from i18n.models import Internationalizable
-
-class TestModel(Internationalizable):
-    """
-    Minimal implementation of a Django model that supports internationalization
-    """
-    title = models.CharField(max_length=255)
-    description = models.TextField()
-
-    @classmethod
-    def internationalizable_fields(cls):
-        return ['title', 'description']
+from i18n.tests.models import TestModel
 
 class InternationalizableTestCase(TestCase):
     """

--- a/i18n/tests/test_internationalizable.py
+++ b/i18n/tests/test_internationalizable.py
@@ -1,0 +1,54 @@
+from unittest2 import TestCase
+
+from django.core.cache import cache
+from django.db import models
+from django.utils import translation
+
+from i18n.models import Internationalizable
+
+class TestModel(Internationalizable):
+    """
+    Minimal implementation of a Django model that supports internationalization
+    """
+    title = models.CharField(max_length=255)
+    description = models.TextField()
+
+    @classmethod
+    def internationalizable_fields(cls):
+        return ['title', 'description']
+
+class InternationalizableTestCase(TestCase):
+    """
+    Basic tests for the Internationalizable abstract model
+    """
+    def setUp(self):
+        TestModel(title="Test Title", description="Test Description").save()
+
+    def test_gather_strings(self):
+        """
+        Test the ability to gather all source strings for a model into a single
+        dict which can be serialized to JSON and uploaded to crowdin
+        """
+        strings = TestModel.gather_strings()
+        self.assertEqual(strings, {
+            "1": {
+                "description": u"Test Description",
+                "title": u"Test Title"
+            }
+        })
+
+    def test_translate_to(self):
+        """
+        Test the ability to load translations from crowdin into an instance of
+        a model
+        """
+        translation.activate('es-mx')
+        cache.set("translations/es_MX/LC_MESSAGES/TestModel.json", {
+            "1": {
+                "description": u"Translated Description",
+                "title": u"Translated Title"
+            }
+        })
+        test_instance = TestModel.objects.get(pk=1)
+        self.assertEqual(test_instance.title, "Translated Title")
+        self.assertEqual(test_instance.description, "Translated Description")

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -77,7 +77,9 @@ class I18nFileWrapper:
     def get_translated_field(cls, name, i18n_key, field, lang):
         translations = cls._load_translations(name, lang)
         try:
-            return translations[i18n_key][field]
+            # Always use keys to access the translations dict, since it's
+            # loaded from JSON
+            return translations[str(i18n_key)][str(field)]
         except KeyError:
             # Could not find the specified string in the translation file,
             # possibly just because the string is new and has not yet been


### PR DESCRIPTION
Since our i18n values are communicated through JSON, we always want to
use strings. Using non-string values will work fine for source string
generation, since the keys will be converted to strings in the
serialization process; but it will fail to find the translations since
the string keys won't be converted back to integers in the
deserialization process.