### PR TITLE
Revert "Hide pdf links for lessons and handouts for csf-2019"

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -296,11 +296,8 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
         return self.i18n_ready
 
     @property
-    def express_or_pre2019(self):
-        return (self.title == "Express" or self.title == "Pre Express") and self.curriculum.slug == 'csf-19'
-
     def has_resource_pdf(self):
-        return self.curriculum.slug not in ['csf-19', 'csf-18', 'csf-1718', 'hoc']
+        return self.curriculum.slug not in ['csf-18', 'csf-1718', 'hoc']
 
     def can_move(self, request, new_parent):
         parent_type = getattr(new_parent, 'content_model', None)

--- a/curricula/templates/curricula/partials/lesson_pills.html
+++ b/curricula/templates/curricula/partials/lesson_pills.html
@@ -3,10 +3,7 @@
 <div class="resource-nav btn-toolbar" role="toolbar" aria-label="Lesson Resources">
     <div class="btn-group btn-group-xs" role="group" aria-label="PDF Buttons">
         <a href="{{ unit.get_absolute_url }}" class="btn" role="button">{% trans 'Unit Overview' %}</a>
-        {# Removing lessons PDF link from Express and Pre Express 2019 until we can fix it #}
-        {% if not unit.express_or_pre2019 %}
         <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'All Lessons PDF' %}</a>
-        {% endif %}
         {# Removing handouts PDF link from CSF until we can fix it #}
         {% if unit.has_resource_pdf %}
         <a href="{{ unit.get_resources_pdf_url }}" class="btn" role="button">{% trans 'All Handouts PDF' %}</a>

--- a/curricula/templates/curricula/partials/unit_pills.html
+++ b/curricula/templates/curricula/partials/unit_pills.html
@@ -7,10 +7,7 @@
       {% if unit.vocab_count > 0 %}<a href="{{ unit.get_vocab_url }}" class="btn" role="button">{% trans 'Vocab' context 'Vocabulary' %}</a>{% endif %}
       {% if unit.block_count > 0 %}<a href="{{ unit.get_blocks_url }}" class="btn" role="button">{% trans 'Code Documentation' %}</a>{% endif %}
       <a href="{{ unit.get_resources_url }}" class="btn" role="button">{% trans 'Other Resources' %}</a>
-        {# Removing lessons PDF link from Express and Pre- Express 2019 until we can fix it #}
-        {% if not unit.express_or_pre2019 %}
-        <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'Lessons PDF' %}</a>
-        {% endif %}
+      <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'Lessons PDF' %}</a>
         {# Removing handouts PDF link from CSF until we can fix it #}
         {% if unit.has_resource_pdf %}
         <a href="{{ unit.get_resources_pdf_url }}" class="btn" role="button">{% trans 'Handouts PDF' %}</a>


### PR DESCRIPTION
Reverts mrjoshida/curriculumbuilder#133

PDFs are working for Express and Pre-Express 2019 now, so reverting this PR to unhide the "Handouts PDF" link for these.