### PR TITLE
install libgnutls28-dev before requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ addons:
     packages:
       - postgresql-server-dev-9.6
 
-install: 
+before_install:
+  - sudo apt-get install -y libgnutls28-dev
+
+install:
   - pip install -r requirements.txt
   - npm install
 


### PR DESCRIPTION
Fixes https://codedotorg.atlassian.net/browse/LP-666

The problem was pycurl failing to install: https://stackoverflow.com/questions/46290556/installing-pycurl-with-fatal-error-gnutls-gnutls-h-no-such-file-or-directory