### PR TITLE
fix syntax for importing and calling urlparse

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -4,8 +4,6 @@ import socket
 
 import os
 
-import urlparse
-
 import dj_database_url
 
 from django.utils.translation import ugettext_lazy as _
@@ -229,7 +227,7 @@ STATICFILES_DIRS = (
 )
 
 if os.environ.get('REDIS_URL', False):
-    redis_url = urlparse.urlparse(os.environ.get('REDIS_URL'))
+    redis_url = urlparse(os.environ.get('REDIS_URL'))
     CACHES = {
         "default": {
             "BACKEND": "redis_cache.RedisCache",


### PR DESCRIPTION
heroku deploys are failing with this error:
```
           redis_url = urlparse.urlparse(os.environ.get('REDIS_URL'))
       AttributeError: 'function' object has no attribute 'urlparse'
```
https://github.com/mrjoshida/curriculumbuilder/blob/d4794440962f4ab8fc90b3812e08b65d2fc55e57/curriculumBuilder/settings.py#L232

@bethanyaconnor tracked it down to this PR: https://github.com/mrjoshida/curriculumbuilder/pull/144
