### PR TITLE
Test curricula rendering routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ before_script:
   - python manage.py migrate
 
 script:
-  - python manage.py test
+  - debug=true python manage.py test

--- a/curricula/tests.py
+++ b/curricula/tests.py
@@ -20,3 +20,7 @@ class IframeDomainRestrictionTestCase(TestCase):
         # Will reject incomplete urls
         self.assertEqual('<iframe></iframe>',
                          richtext_filters('<iframe src="docs.google.com"></iframe>'))
+
+    def test_homepage(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)

--- a/curricula/tests.py
+++ b/curricula/tests.py
@@ -21,6 +21,7 @@ class IframeDomainRestrictionTestCase(TestCase):
         self.assertEqual('<iframe></iframe>',
                          richtext_filters('<iframe src="docs.google.com"></iframe>'))
 
+class CurriculaRenderingTestCase(TestCase):
     def test_homepage(self):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)

--- a/curricula/tests.py
+++ b/curricula/tests.py
@@ -2,6 +2,10 @@ from django.test import TestCase
 
 from mezzanine.core.templatetags.mezzanine_tags import richtext_filters
 
+from curricula.models import Curriculum, Unit
+from lessons.models import Lesson
+from standards.models import Category, GradeBand, Framework
+
 class IframeDomainRestrictionTestCase(TestCase):
     """
     Test the RICHTEXT_ALLOWED_ATTRIBUTES logic that will only allow iframes to
@@ -22,6 +26,79 @@ class IframeDomainRestrictionTestCase(TestCase):
                          richtext_filters('<iframe src="docs.google.com"></iframe>'))
 
 class CurriculaRenderingTestCase(TestCase):
+    def setUp(self):
+        self.test_curriculum = Curriculum.objects.create(title="Test Curriculum", slug="test-curriculum")
+        self.test_unit = Unit.objects.create(
+            title="Test Unit",
+            parent=self.test_curriculum,
+            slug="test-unit",
+            description="Test unit description",
+            show_calendar=True
+        )
+        self.hoc_unit = Unit.objects.create(
+            title="HoC Unit",
+            parent=self.test_curriculum,
+            slug="hoc-unit",
+            description="Hoc unit description",
+            lesson_template_override="curricula/hoc_lesson.html"
+        )
+        self.csf_unit = Unit.objects.create(
+            title="CSF Unit",
+            parent=self.test_curriculum,
+            slug="csf-unit",
+            description="CSF unit description",
+            lesson_template_override="curricula/csf_lesson.html"
+        )
+        self.pl_unit = Unit.objects.create(
+            title="PL Unit",
+            parent=self.test_curriculum,
+            slug="pl-unit",
+            description="PL unit description",
+            lesson_template_override="curricula/pl_lesson.html"
+        )
+        self.test_lesson = Lesson.objects.create(title="Test Lesson", parent=self.test_unit)
+        self.hoc_lesson = Lesson.objects.create(title="HoC Lesson", parent=self.hoc_unit)
+        self.csf_lesson = Lesson.objects.create(title="CSF Lesson", parent=self.csf_unit)
+        self.pl_lesson = Lesson.objects.create(title="PL Lesson", parent=self.pl_unit)
+
     def test_homepage(self):
         response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_render_curriculum(self):
+        response = self.client.get('/test-curriculum/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_render_unit(self):
+        response = self.client.get('/test-curriculum/test-unit/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/csf-unit/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/hoc-unit/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/pl-unit/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/glance/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/vocab/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/code/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/resources/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/objectives/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/unit_feedback/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/?pdf=1')
+        self.assertEqual(response.status_code, 200)
+
+    def test_render_lesson(self):
+        response = self.client.get('/test-curriculum/test-unit/1/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/hoc-unit/1/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/csf-unit/1/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/pl-unit/1/')
         self.assertEqual(response.status_code, 200)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -95,8 +95,6 @@ class CurriculaRenderingTestCase(TestCase):
     def test_render_curriculum(self):
         response = self.client.get('/test-curriculum/')
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/test-curriculum/pdf')
-        self.assertEqual(response.status_code, 200)
 
     def test_render_unit(self):
         response = self.client.get('/test-curriculum/test-unit/')
@@ -115,8 +113,6 @@ class CurriculaRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/resources/')
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/test-curriculum/test-unit_resources.pdf')
-        self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/objectives/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/unit_feedback/')
@@ -128,8 +124,6 @@ class CurriculaRenderingTestCase(TestCase):
 
     def test_render_lesson(self):
         response = self.client.get('/test-curriculum/test-unit/1/')
-        self.assertEqual(response.status_code, 200)
-        response = self.client.get('/test-curriculum/test-unit/1/pdf/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/hoc-unit/1/')
         self.assertEqual(response.status_code, 200)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 
 from curricula.models import Curriculum, Unit
-from lessons.models import Lesson
+from lessons.models import Lesson, Resource
 
 
 class CurriculaRenderingTestCase(TestCase):
@@ -12,7 +12,7 @@ class CurriculaRenderingTestCase(TestCase):
         user.save()
         self.client.login(username='admin', password='12345')
 
-        self.test_curriculum = Curriculum.objects.create(title="Test Curriculum", slug="test-curriculum")
+        self.test_curriculum = Curriculum.objects.create(title="Test Curriculum", slug="test-curriculum", assessment_commentary="Assessment Commentary")
         self.test_unit = Unit.objects.create(
             title="Test Unit",
             parent=self.test_curriculum,
@@ -41,11 +41,39 @@ class CurriculaRenderingTestCase(TestCase):
             description="PL unit description",
             lesson_template_override="curricula/pl_lesson.html"
         )
-
-        self.test_lesson = Lesson.objects.create(title="Test Lesson", parent=self.test_unit, overview="Overview")
-        self.hoc_lesson = Lesson.objects.create(title="HoC Lesson", parent=self.hoc_unit)
-        self.csf_lesson = Lesson.objects.create(title="CSF Lesson", parent=self.csf_unit)
-        self.pl_lesson = Lesson.objects.create(title="PL Lesson", parent=self.pl_unit)
+        resource = Resource.objects.create(
+            name="Test Resource",
+            slug="test-resource",
+            student=True
+        )
+        self.test_lesson = Lesson.objects.create(
+            title="Test Lesson",
+            parent=self.test_unit,
+            overview="Overview",
+            prep="Prep"
+        )
+        self.test_lesson.resources.add(resource)
+        self.hoc_lesson = Lesson.objects.create(
+            title="HoC Lesson",
+            parent=self.hoc_unit,
+            overview="HoC Overview",
+            prep="Prep"
+        )
+        self.hoc_lesson.resources.add(resource)
+        self.csf_lesson = Lesson.objects.create(
+            title="CSF Lesson",
+            parent=self.csf_unit,
+            overview="CSF Overview",
+            prep="Prep"
+        )
+        self.csf_lesson.resources.add(resource)
+        self.pl_lesson = Lesson.objects.create(
+            title="PL Lesson",
+            parent=self.pl_unit,
+            overview="PL Overview",
+            prep="Prep"
+        )
+        self.pl_lesson.resources.add(resource)
 
     def test_homepage(self):
         response = self.client.get('/')

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -12,7 +12,20 @@ class CurriculaRenderingTestCase(TestCase):
         user.save()
         self.client.login(username='admin', password='12345')
 
-        self.test_curriculum = Curriculum.objects.create(title="Test Curriculum", slug="test-curriculum", assessment_commentary="Assessment Commentary")
+        self.test_curriculum = Curriculum.objects.create(
+            title="Test Curriculum",
+            slug="test-curriculum",
+            assessment_commentary="Assessment Commentary")
+        self.csf_curriculum = Curriculum.objects.create(
+            title="CSF Curriculum",
+            slug="csf-curriculum",
+            assessment_commentary="CSF Commentary",
+            unit_template_override='curricula/csf_unit.html')
+        self.pl_curriculum = Curriculum.objects.create(
+            title="PL Curriculum",
+            slug="pl-curriculum",
+            assessment_commentary="PL Commentary",
+            unit_template_override='curricula/pl_unit.html')
         self.test_unit = Unit.objects.create(
             title="Test Unit",
             parent=self.test_curriculum,
@@ -29,14 +42,14 @@ class CurriculaRenderingTestCase(TestCase):
         )
         self.csf_unit = Unit.objects.create(
             title="CSF Unit",
-            parent=self.test_curriculum,
+            parent=self.csf_curriculum,
             slug="csf-unit",
             description="CSF unit description",
             lesson_template_override="curricula/csf_lesson.html"
         )
         self.pl_unit = Unit.objects.create(
             title="PL Unit",
-            parent=self.test_curriculum,
+            parent=self.pl_curriculum,
             slug="pl-unit",
             description="PL unit description",
             lesson_template_override="curricula/pl_lesson.html"
@@ -86,11 +99,11 @@ class CurriculaRenderingTestCase(TestCase):
     def test_render_unit(self):
         response = self.client.get('/test-curriculum/test-unit/')
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/test-curriculum/csf-unit/')
+        response = self.client.get('/csf-curriculum/csf-unit/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/hoc-unit/')
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/test-curriculum/pl-unit/')
+        response = self.client.get('/pl-curriculum/pl-unit/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/glance/')
         self.assertEqual(response.status_code, 200)
@@ -106,15 +119,17 @@ class CurriculaRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/?pdf=1')
         self.assertEqual(response.status_code, 200)
+        response = self.client.get('/pl-curriculum/pl-unit/?pdf=1')
+        self.assertEqual(response.status_code, 200)
 
     def test_render_lesson(self):
         response = self.client.get('/test-curriculum/test-unit/1/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/hoc-unit/1/')
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/test-curriculum/csf-unit/1/')
+        response = self.client.get('/csf-curriculum/csf-unit/1/')
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/test-curriculum/pl-unit/1/')
+        response = self.client.get('/pl-curriculum/pl-unit/1/')
         self.assertEqual(response.status_code, 200)
 
     def test_render_lesson_with_levels(self):

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -95,6 +95,8 @@ class CurriculaRenderingTestCase(TestCase):
     def test_render_curriculum(self):
         response = self.client.get('/test-curriculum/')
         self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/pdf')
+        self.assertEqual(response.status_code, 200)
 
     def test_render_unit(self):
         response = self.client.get('/test-curriculum/test-unit/')
@@ -113,6 +115,8 @@ class CurriculaRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/resources/')
         self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit_resources.pdf')
+        self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/objectives/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/test-unit/unit_feedback/')
@@ -124,6 +128,8 @@ class CurriculaRenderingTestCase(TestCase):
 
     def test_render_lesson(self):
         response = self.client.get('/test-curriculum/test-unit/1/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/test-curriculum/test-unit/1/pdf/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/hoc-unit/1/')
         self.assertEqual(response.status_code, 200)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -1,10 +1,16 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
 
 from curricula.models import Curriculum, Unit
 from lessons.models import Lesson
 
 class CurriculaRenderingTestCase(TestCase):
     def setUp(self):
+        user = User.objects.create_user(username='admin', password='12345')
+        user.is_staff = True
+        user.save()
+        self.client.login(username='admin', password='12345')
+
         self.test_curriculum = Curriculum.objects.create(title="Test Curriculum", slug="test-curriculum")
         self.test_unit = Unit.objects.create(
             title="Test Unit",

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -1,29 +1,7 @@
 from django.test import TestCase
 
-from mezzanine.core.templatetags.mezzanine_tags import richtext_filters
-
 from curricula.models import Curriculum, Unit
 from lessons.models import Lesson
-from standards.models import Category, GradeBand, Framework
-
-class IframeDomainRestrictionTestCase(TestCase):
-    """
-    Test the RICHTEXT_ALLOWED_ATTRIBUTES logic that will only allow iframes to
-    render certain domains
-    """
-
-    def test_allow_google_doc_iframes(self):
-        richtext = '<iframe src="http://docs.google.com"></iframe>'
-        self.assertEqual(richtext, richtext_filters(richtext))
-
-    def test_reject_other_iframes(self):
-        # Will reject non-google domains
-        self.assertEqual('<iframe></iframe>',
-                         richtext_filters('<iframe src="http://example.com"></iframe>'))
-
-        # Will reject incomplete urls
-        self.assertEqual('<iframe></iframe>',
-                         richtext_filters('<iframe src="docs.google.com"></iframe>'))
 
 class CurriculaRenderingTestCase(TestCase):
     def setUp(self):

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from curricula.models import Curriculum, Unit
 from lessons.models import Lesson
 
+
 class CurriculaRenderingTestCase(TestCase):
     def setUp(self):
         user = User.objects.create_user(username='admin', password='12345')
@@ -40,7 +41,8 @@ class CurriculaRenderingTestCase(TestCase):
             description="PL unit description",
             lesson_template_override="curricula/pl_lesson.html"
         )
-        self.test_lesson = Lesson.objects.create(title="Test Lesson", parent=self.test_unit)
+
+        self.test_lesson = Lesson.objects.create(title="Test Lesson", parent=self.test_unit, overview="Overview")
         self.hoc_lesson = Lesson.objects.create(title="HoC Lesson", parent=self.hoc_unit)
         self.csf_lesson = Lesson.objects.create(title="CSF Lesson", parent=self.csf_unit)
         self.pl_lesson = Lesson.objects.create(title="PL Lesson", parent=self.pl_unit)
@@ -85,4 +87,23 @@ class CurriculaRenderingTestCase(TestCase):
         response = self.client.get('/test-curriculum/csf-unit/1/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/test-curriculum/pl-unit/1/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_render_lesson_with_levels(self):
+        stage = {
+            "levels": [{
+                "path": "/s/dance/stage/1/puzzle/1",
+                "name": "Dance_Party_11",
+                "mini_rubric": True
+            },{
+                "path": "/s/dance/stage/1/puzzle/2",
+                "name": "Dance_Party_22",
+                "teacher_markdown": "teacher markdown",
+                "named_level": True
+            }],
+            "stageName": "test stage"
+        }
+        self.test_lesson.stage = stage
+        self.test_lesson.save()
+        response = self.client.get('/test-curriculum/test-unit/1/')
         self.assertEqual(response.status_code, 200)

--- a/curricula/tests/test_iframe.py
+++ b/curricula/tests/test_iframe.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from mezzanine.core.templatetags.mezzanine_tags import richtext_filters
+
+class IframeDomainRestrictionTestCase(TestCase):
+    """
+    Test the RICHTEXT_ALLOWED_ATTRIBUTES logic that will only allow iframes to
+    render certain domains
+    """
+
+    def test_allow_google_doc_iframes(self):
+        richtext = '<iframe src="http://docs.google.com"></iframe>'
+        self.assertEqual(richtext, richtext_filters(richtext))
+
+    def test_reject_other_iframes(self):
+        # Will reject non-google domains
+        self.assertEqual('<iframe></iframe>',
+                         richtext_filters('<iframe src="http://example.com"></iframe>'))
+
+        # Will reject incomplete urls
+        self.assertEqual('<iframe></iframe>',
+                         richtext_filters('<iframe src="docs.google.com"></iframe>'))


### PR DESCRIPTION
Add a few tests which render various views under `curricula/`. This PR does the minimum in each test needed to get code coverage numbers up, which is an important metric for when we are ready to move to python 3.

This increases our coverage within `curricula/` from 4% to 57%, and increases our overall coverage from 17% to 40%.

New coverage report: [cb-coverage-report-02.txt](https://github.com/mrjoshida/curriculumbuilder/files/3618099/cb-coverage-report-02.txt)
