### PR TITLE
Clean up between i18n tests

### DIFF
--- a/i18n/tests/test_internationalizable.py
+++ b/i18n/tests/test_internationalizable.py
@@ -10,8 +10,10 @@ class InternationalizableTestCase(TestCase):
     Basic tests for the Internationalizable abstract model
     """
     def setUp(self):
-        TestModel.objects.all().delete()
         self.test_model = TestModel(id=1, title="Test Title", description="Test Description").save()
+
+    def tearDown(self):
+        TestModel.objects.all().delete()
 
     def test_gather_strings(self):
         """

--- a/i18n/tests/test_internationalizable.py
+++ b/i18n/tests/test_internationalizable.py
@@ -10,7 +10,8 @@ class InternationalizableTestCase(TestCase):
     Basic tests for the Internationalizable abstract model
     """
     def setUp(self):
-        TestModel(title="Test Title", description="Test Description").save()
+        TestModel.objects.all().delete()
+        self.test_model = TestModel(id=1, title="Test Title", description="Test Description").save()
 
     def test_gather_strings(self):
         """


### PR DESCRIPTION
A small tweak to i18n tests allows them to pass when the `--keepdb` flag is specified, which reduces the amount of time it takes a developer to run all unit tests locally from 1m23s to 23s.

```
(cb) Dave-MBP:~/src/cb (keepdb-i18n)$ time debug=true ./manage.py test --keepdb
Using existing test database for alias 'default'...
...
Ran 933 tests in 5.102s
OK
Preserving test database for alias 'default'...

real	0m23.131s
user	0m21.181s
sys	0m2.393s
```

Test cases which derive from Django's `TestCase` already wrap DB activity in a transaction, eliminating the need to explicitly clean up.
