### PR TITLE
Category / Standards import/export improvements

### DIFF
--- a/standards/admin.py
+++ b/standards/admin.py
@@ -67,7 +67,7 @@ class FrameworkAdmin(admin.ModelAdmin):
 
 class StandardResource(resources.ModelResource):
     category = fields.Field(column_name='category', attribute='category',
-                            widget=ForeignKeyWidget(Category, 'shortcode'))
+                            widget=CategoryForeignKeyWidget(Category, 'shortcode'))
     gradeband = fields.Field(column_name='gradeband', attribute='gradeband',
                              widget=ForeignKeyWidget(GradeBand, 'name'))
     framework = fields.Field(column_name='framework', attribute='framework',

--- a/standards/models.py
+++ b/standards/models.py
@@ -77,7 +77,11 @@ class Category(Internationalizable):
     parent = models.ForeignKey('self', blank=True, null=True, related_name="children")
 
     def __unicode__(self):
-        return "%s %s: %s" % (self.framework.slug, self.shortcode, self.name)
+        # When importing via django-import-export, categories may be listed before the framework is assigned
+        if self.framework:
+            return "%s %s: %s" % (self.framework.slug, self.shortcode, self.name)
+        else:
+            return self.shortcode
 
     class Meta:
         ordering = ['framework', 'shortcode']


### PR DESCRIPTION
The new CSP framework has introduced some issues in our import/export system due to duplicate shortcodes used in both the older and newer framework. This addresses that by forcing the import mechanism to lookup categories by both shortcode and framework